### PR TITLE
Handle some fields that may be strings or numbers

### DIFF
--- a/unidev/uap.go
+++ b/unidev/uap.go
@@ -181,7 +181,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 			"device_mac":   u.Mac,
 			"name":         p.Name,
 			"wlangroup_id": p.WlangroupID,
-			"channel":      p.Channel, // not the channel #
+			"channel":      strconv.Itoa(p.Channel.Value),
 			"radio":        p.Radio,
 		}
 		fields := map[string]interface{}{
@@ -196,7 +196,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 			"min_txpower":          p.MinTxpower,
 			"nss":                  p.Nss,
 			"radio_caps":           p.RadioCaps,
-			"tx_power":             p.TxPower,
+			"tx_power":             p.TxPower.Value,
 			"tx_power_mode":        p.TxPowerMode,
 		}
 

--- a/unidev/uap_type.go
+++ b/unidev/uap_type.go
@@ -1,5 +1,36 @@
 package unidev
 
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+)
+
+// FlexInt provides a container and unmarshalling for fields that may be
+// numbers or strings in the Unifi API
+type FlexInt struct {
+	Value int
+}
+
+func (this FlexInt) UnmarshalJSON(b []byte) error {
+	var unk interface{}
+	err := json.Unmarshal(b, &unk)
+	if err != nil {
+		return err
+	}
+	switch i := unk.(type) {
+	case float64:
+		this.Value = int(i)
+		return nil
+	case string:
+		this.Value, err = strconv.Atoi(i)
+		return err
+	default:
+		return errors.New("Cannot unmarshal to FlexInt")
+	}
+
+}
+
 // UAP is a Unifi Access Point.
 type UAP struct {
 	/* This was auto generated and then slowly edited by hand
@@ -119,7 +150,7 @@ type UAP struct {
 	RadioTable []struct {
 		BuiltinAntGain     float64 `json:"builtin_ant_gain"`
 		BuiltinAntenna     bool    `json:"builtin_antenna"`
-		Channel            string  `json:"channel"`
+		Channel            FlexInt `json:"channel"`
 		CurrentAntennaGain float64 `json:"current_antenna_gain"`
 		Ht                 string  `json:"ht"`
 		MaxTxpower         float64 `json:"max_txpower"`
@@ -129,7 +160,7 @@ type UAP struct {
 		Nss                float64 `json:"nss"`
 		Radio              string  `json:"radio"`
 		RadioCaps          float64 `json:"radio_caps"`
-		TxPower            string  `json:"tx_power"`
+		TxPower            FlexInt `json:"tx_power"`
 		TxPowerMode        string  `json:"tx_power_mode"`
 		WlangroupID        string  `json:"wlangroup_id"`
 		HasDfs             bool    `json:"has_dfs,omitempty"`


### PR DESCRIPTION
Different access points (even on the same controller) may return some fields as either JSON strings or numbers. For example, a UAP-AC-Pro and a UAP-HD-Nano, both running firmware 3.9.54.9373 on controller version 5.9.29 had these as part of their responses:

```json
"radio_table" : [ { "antenna_gain" : 6 , "builtin_ant_gain" : 3 , "builtin_antenna" : true , "channel" : "8" , "current_antenna_gain" : 0 , "ht" : "20" , "max_txpower" : 22 , "min_rssi_enabled" : false , "min_txpower" : 6 , "name" : "wifi0" , "nss" : 3 , "radio" : "ng" , "radio_caps" : 16420 , "sens_level_enabled" : false , "tx_power" : "6" , "tx_power_mode" : "custom" , "vwire_enabled" : false , "wlangroup_id" : "56ad32313004bc08e4f9ec7e"} , { "antenna_gain" : 6 , "builtin_ant_gain" : 3 , "builtin_antenna" : true , "channel" : "157" , "current_antenna_gain" : 0 , "hard_noise_floor_enabled" : false , "has_dfs" : true , "has_fccdfs" : true , "ht" : "80" , "is_11ac" : true , "max_txpower" : 22 , "min_rssi" : -65 , "min_rssi_enabled" : true , "min_txpower" : 6 , "name" : "wifi1" , "nss" : 3 , "radio" : "na" , "radio_caps" : 50479140 , "sens_level_enabled" : false , "tx_power" : "22" , "tx_power_mode" : "medium" , "vwire_enabled" : false , "wlangroup_id" : "56ad32313004bc08e4f9ec7e"}] , 
```

```json
"radio_table" : [ { "antenna_gain" : 6 , "builtin_ant_gain" : 0 , "builtin_antenna" : true , "channel" : 5 , "current_antenna_gain" : 0 , "hard_noise_floor_enabled" : false , "ht" : "20" , "max_txpower" : 22 , "min_rssi_enabled" : false , "min_txpower" : 6 , "name" : "ra0" , "nss" : 2 , "radio" : "ng" , "radio_caps" : 147476 , "sens_level_enabled" : false , "tx_power" : 22 , "tx_power_mode" : "low" , "vwire_enabled" : false , "wlangroup_id" : "56ad32313004bc08e4f9ec7e"} , { "antenna_gain" : 6 , "builtin_ant_gain" : 0 , "builtin_antenna" : true , "channel" : 48 , "current_antenna_gain" : 0 , "hard_noise_floor_enabled" : false , "has_dfs" : true , "has_fccdfs" : true , "has_ht160" : true , "ht" : "160" , "is_11ac" : true , "max_txpower" : 25 , "min_rssi_enabled" : false , "min_txpower" : 6 , "name" : "rai0" , "nss" : 4 , "radio" : "na" , "radio_caps" : 251805700 , "sens_level_enabled" : false , "tx_power" : 25 , "tx_power_mode" : "medium" , "vwire_enabled" : false , "wlangroup_id" : "56ad32313004bc08e4f9ec7e"}] , 
```

In order to handle this, unmarshal to a new container type.