### PR TITLE
Fix a few bugs.

### DIFF
--- a/unidev/uap.go
+++ b/unidev/uap.go
@@ -181,7 +181,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 			"device_mac":   u.Mac,
 			"name":         p.Name,
 			"wlangroup_id": p.WlangroupID,
-			"channel":      strconv.Itoa(p.Channel.Value),
+			"channel":      strconv.Itoa(int(p.Channel)),
 			"radio":        p.Radio,
 		}
 		fields := map[string]interface{}{
@@ -196,7 +196,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 			"min_txpower":          p.MinTxpower,
 			"nss":                  p.Nss,
 			"radio_caps":           p.RadioCaps,
-			"tx_power":             p.TxPower.Value,
+			"tx_power":             p.TxPower,
 			"tx_power_mode":        p.TxPowerMode,
 		}
 

--- a/unidev/uap_type.go
+++ b/unidev/uap_type.go
@@ -1,36 +1,5 @@
 package unidev
 
-import (
-	"encoding/json"
-	"errors"
-	"strconv"
-)
-
-// FlexInt provides a container and unmarshalling for fields that may be
-// numbers or strings in the Unifi API
-type FlexInt struct {
-	Value int
-}
-
-func (this FlexInt) UnmarshalJSON(b []byte) error {
-	var unk interface{}
-	err := json.Unmarshal(b, &unk)
-	if err != nil {
-		return err
-	}
-	switch i := unk.(type) {
-	case float64:
-		this.Value = int(i)
-		return nil
-	case string:
-		this.Value, err = strconv.Atoi(i)
-		return err
-	default:
-		return errors.New("Cannot unmarshal to FlexInt")
-	}
-
-}
-
 // UAP is a Unifi Access Point.
 type UAP struct {
 	/* This was auto generated and then slowly edited by hand

--- a/unidev/unidev.go
+++ b/unidev/unidev.go
@@ -47,9 +47,10 @@ func (value *FlexInt) UnmarshalJSON(b []byte) error {
 		*value = FlexInt(i)
 		return nil
 	case string:
-		j, err := strconv.Atoi(i)
+		// If it's a string like the word "auto" just set the integer to 0 and proceed.
+		j, _ := strconv.Atoi(i)
 		*value = FlexInt(j)
-		return err
+		return nil
 	default:
 		return errors.New("Cannot unmarshal to FlexInt")
 	}

--- a/unidev/unidev.go
+++ b/unidev/unidev.go
@@ -3,6 +3,7 @@ package unidev
 import (
 	"bytes"
 	"crypto/tls"
+	"log"
 	"net/http"
 	"net/http/cookiejar"
 
@@ -29,6 +30,9 @@ type AuthedReq struct {
 	baseURL string
 }
 
+// StringInt is used to unmarshal quoted integers in JSON responses.
+type StringInt int
+
 // AuthController creates a http.Client with authenticated cookies.
 // Used to make additional, authenticated requests to the APIs.
 func AuthController(user, pass, url string) (*AuthedReq, error) {
@@ -41,11 +45,20 @@ func AuthController(user, pass, url string) (*AuthedReq, error) {
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 		Jar:       jar,
 	}, url}
-	if req, err := authReq.UniReq(LoginPath, json); err != nil {
+	req, err := authReq.UniReq(LoginPath, json)
+	if err != nil {
 		return nil, errors.Wrap(err, "UniReq(LoginPath, json)")
-	} else if resp, err := authReq.Do(req); err != nil {
+	}
+	resp, err := authReq.Do(req)
+	if err != nil {
 		return nil, errors.Wrap(err, "authReq.Do(req)")
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Println("resp.Body.Close():", err) // Not fatal. Just log it.
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("authentication failed (%v): %v (status: %v/%v)",
 			user, url+LoginPath, resp.StatusCode, resp.Status)
 	}

--- a/unidev/unidev_test.go
+++ b/unidev/unidev_test.go
@@ -21,6 +21,6 @@ func TestFlexInt(t *testing.T) {
 	a.EqualValues(FlexInt(5), r.Channel)
 	a.Nil(json.Unmarshal(seven, &r))
 	a.EqualValues(FlexInt(7), r.Channel)
-	a.NotNil(json.Unmarshal(auto, &r))
+	a.Nil(json.Unmarshal(auto, &r), "a regular string must not produce an unmarshal error")
 	a.EqualValues(FlexInt(0), r.Channel)
 }

--- a/unidev/unidev_test.go
+++ b/unidev/unidev_test.go
@@ -1,0 +1,23 @@
+package unidev
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlexInt(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	five := []byte(`{"channel": "5"}`)
+	seven := []byte(`{"channel": 7}`)
+	type reply struct {
+		Channel FlexInt `json:"channel"`
+	}
+	var r reply
+	a.Nil(json.Unmarshal(five, &r))
+	a.EqualValues(FlexInt(5), r.Channel)
+	a.Nil(json.Unmarshal(seven, &r))
+	a.EqualValues(FlexInt(7), r.Channel)
+}

--- a/unidev/unidev_test.go
+++ b/unidev/unidev_test.go
@@ -12,6 +12,7 @@ func TestFlexInt(t *testing.T) {
 	a := assert.New(t)
 	five := []byte(`{"channel": "5"}`)
 	seven := []byte(`{"channel": 7}`)
+	auto := []byte(`{"channel": "auto"}`)
 	type reply struct {
 		Channel FlexInt `json:"channel"`
 	}
@@ -20,4 +21,6 @@ func TestFlexInt(t *testing.T) {
 	a.EqualValues(FlexInt(5), r.Channel)
 	a.Nil(json.Unmarshal(seven, &r))
 	a.EqualValues(FlexInt(7), r.Channel)
+	a.NotNil(json.Unmarshal(auto, &r))
+	a.EqualValues(FlexInt(0), r.Channel)
 }

--- a/unidev/unidev_test.go
+++ b/unidev/unidev_test.go
@@ -10,17 +10,15 @@ import (
 func TestFlexInt(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	five := []byte(`{"channel": "5"}`)
-	seven := []byte(`{"channel": 7}`)
-	auto := []byte(`{"channel": "auto"}`)
 	type reply struct {
 		Channel FlexInt `json:"channel"`
 	}
 	var r reply
-	a.Nil(json.Unmarshal(five, &r))
+	a.Nil(json.Unmarshal([]byte(`{"channel": "5"}`), &r))
 	a.EqualValues(FlexInt(5), r.Channel)
-	a.Nil(json.Unmarshal(seven, &r))
+	a.Nil(json.Unmarshal([]byte(`{"channel": 7}`), &r))
 	a.EqualValues(FlexInt(7), r.Channel)
-	a.Nil(json.Unmarshal(auto, &r), "a regular string must not produce an unmarshal error")
+	a.Nil(json.Unmarshal([]byte(`{"channel": "auto"}`), &r),
+		"a regular string must not produce an unmarshal error")
 	a.EqualValues(FlexInt(0), r.Channel)
 }


### PR DESCRIPTION
This contribution fixes the un-closed http body that happens during initial authentication. I also moved around the new `FlexInt` implementation and made it not throw an error for a normal string. My `tx_power` is set to `"auto"` so it was not working as-is. This fixes the bug and should continue to work. The code as-is can be re-used when this happens again.