### PR TITLE
Keep String and Number for FlexInt type. Resolve uptime unmarhsal bug.

### DIFF
--- a/unidev/uap.go
+++ b/unidev/uap.go
@@ -181,7 +181,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 			"device_mac":   u.Mac,
 			"name":         p.Name,
 			"wlangroup_id": p.WlangroupID,
-			"channel":      strconv.Itoa(int(p.Channel)),
+			"channel":      p.Channel.String,
 			"radio":        p.Radio,
 		}
 		fields := map[string]interface{}{
@@ -196,7 +196,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 			"min_txpower":          p.MinTxpower,
 			"nss":                  p.Nss,
 			"radio_caps":           p.RadioCaps,
-			"tx_power":             p.TxPower,
+			"tx_power":             p.TxPower.Number,
 			"tx_power_mode":        p.TxPowerMode,
 		}
 

--- a/unidev/uap.go
+++ b/unidev/uap.go
@@ -62,7 +62,7 @@ func (u UAP) Points() ([]*influx.Point, error) {
 		"rx_bytes-d":                 u.RxBytesD,
 		"tx_bytes":                   u.TxBytes,
 		"tx_bytes-d":                 u.TxBytesD,
-		"uptime":                     u.Uptime,
+		"uptime":                     u.Uptime.Number,
 		"considered_lost_at":         u.ConsideredLostAt,
 		"next_heartbeat_at":          u.NextHeartbeatAt,
 		"scanning":                   u.Scanning,

--- a/unidev/uap_type.go
+++ b/unidev/uap_type.go
@@ -306,7 +306,7 @@ type UAP struct {
 		UplinkRemotePort int     `json:"uplink_remote_port"`
 	} `json:"uplink"`
 	UplinkTable []interface{} `json:"uplink_table"`
-	Uptime      float64       `json:"uptime"`
+	Uptime      FlexInt       `json:"uptime"`
 	UserNumSta  int           `json:"user-num_sta"`
 	VapTable    []struct {
 		ApMac               string  `json:"ap_mac"`

--- a/unidev/unidev.go
+++ b/unidev/unidev.go
@@ -34,22 +34,25 @@ type AuthedReq struct {
 
 // FlexInt provides a container and unmarshalling for fields that may be
 // numbers or strings in the Unifi API
-type FlexInt int
+type FlexInt struct {
+	Number float64
+	String string
+}
 
 // UnmarshalJSON converts a string or number to an integer.
-func (value *FlexInt) UnmarshalJSON(b []byte) error {
+func (f *FlexInt) UnmarshalJSON(b []byte) error {
 	var unk interface{}
 	if err := json.Unmarshal(b, &unk); err != nil {
 		return err
 	}
 	switch i := unk.(type) {
 	case float64:
-		*value = FlexInt(i)
+		f.Number = i
+		f.String = strconv.FormatFloat(i, 'f', -1, 64)
 		return nil
 	case string:
-		// If it's a string like the word "auto" just set the integer to 0 and proceed.
-		j, _ := strconv.Atoi(i)
-		*value = FlexInt(j)
+		f.String = i
+		f.Number, _ = strconv.ParseFloat(i, 64)
 		return nil
 	default:
 		return errors.New("Cannot unmarshal to FlexInt")

--- a/unidev/unidev_test.go
+++ b/unidev/unidev_test.go
@@ -10,15 +10,23 @@ import (
 func TestFlexInt(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	type reply struct {
-		Channel FlexInt `json:"channel"`
+	type testReply struct {
+		Five  FlexInt `json:"five"`
+		Seven FlexInt `json:"seven"`
+		Auto  FlexInt `json:"auto"`
 	}
-	var r reply
-	a.Nil(json.Unmarshal([]byte(`{"channel": "5"}`), &r))
-	a.EqualValues(FlexInt(5), r.Channel)
-	a.Nil(json.Unmarshal([]byte(`{"channel": 7}`), &r))
-	a.EqualValues(FlexInt(7), r.Channel)
+	var r testReply
+	// test unmarshalling the custom type three times with different values.
+	a.Nil(json.Unmarshal([]byte(`{"five": "5", "seven": 7, "auto": "auto"}`), &r))
+	// test number in string.
+	a.EqualValues(5, r.Five.Number)
+	a.EqualValues("5", r.Five.String)
+	// test number.
+	a.EqualValues(7, r.Seven.Number)
+	a.EqualValues("7", r.Seven.String)
+	// test string.
 	a.Nil(json.Unmarshal([]byte(`{"channel": "auto"}`), &r),
 		"a regular string must not produce an unmarshal error")
-	a.EqualValues(FlexInt(0), r.Channel)
+	a.EqualValues(0, r.Auto.Number)
+	a.EqualValues("auto", r.Auto.String)
 }


### PR DESCRIPTION
Changing the FlexInt type around some more. Decided I wanted to keep the string and the number, then decide later which one is more useful. 

Also addressing the bug reported in #6. This should allow `UAP.uptime` to be a string or number as well.