### PR TITLE
Update build. Allow less "building" to create all the packages.

### DIFF
--- a/scripts/before-remove.sh
+++ b/scripts/before-remove.sh
@@ -2,5 +2,9 @@
 
 # This file is used by rpm and deb packages. FPM use.
 
+if [ "$1" = "upgrade" ] || [ "$1" = "1" ] ; then
+  exit 0
+fi
+
 systemctl stop unifi-poller
 systemctl disable unifi-poller

--- a/scripts/build_linux_packages.sh
+++ b/scripts/build_linux_packages.sh
@@ -20,6 +20,7 @@ fi
 
 echo "Building '${OUTPUT}' package."
 
+# eh, don't change these.
 PREFIX=
 BINFIX=/usr
 
@@ -37,6 +38,7 @@ mkdir -p package_build/lib/systemd/system
 sed "s#ExecStart.*#ExecStart=${BINFIX}/bin/${BINARY} --config=${PREFIX}/etc/${BINARY}/up.conf#" \
   init/systemd/unifi-poller.service > package_build/lib/systemd/system/${BINARY}.service
 
+# Make a package.
 fpm -s dir -t ${OUTPUT} \
   --name ${BINARY} \
   --version ${VERSION} \

--- a/scripts/build_linux_packages.sh
+++ b/scripts/build_linux_packages.sh
@@ -28,7 +28,7 @@ rm -rf package_build
 mkdir -p package_build${BINFIX}/bin package_build${PREFIX}/etc/${BINARY} package_build${BINFIX}/share/man/man1
 
 # Copy the binary, config file and man page into the env.
-cp ${BINARY} package_build${BINFIX}/bin
+cp ${BINARY}.linux package_build${BINFIX}/bin/${BINARY}
 cp *.1.gz package_build${BINFIX}/share/man/man1
 cp examples/up.conf.example package_build${PREFIX}/etc/${BINARY}/up.conf
 
@@ -42,4 +42,8 @@ fpm -s dir -t ${OUTPUT} \
   --version ${VERSION} \
   --after-install scripts/after-install.sh \
   --before-remove scripts/before-remove.sh \
+  --license MIT \
+  --url 'https://github.com/davidnewhall/unifi-poller' \
+  --maintainer 'david at sleepers dot pro' \
+  --description 'This daemon polls a Unifi controller at a short interval and stores the collected metric data in an Influx Database.' \
   --chdir package_build

--- a/scripts/build_osx_package.sh
+++ b/scripts/build_osx_package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script builds a simple macos Installer pkg. Run by the Makefile.
-# Use: `make osx`
+# Use: `make osxpkg`
 
 OUTPUT=$1
 BINARY=unifi-poller

--- a/scripts/build_osx_package.sh
+++ b/scripts/build_osx_package.sh
@@ -24,7 +24,7 @@ mkdir -p package_build${BINFIX}/bin package_build${PREFIX}/etc/${BINARY} package
 mkdir -p package_build${PREFIX}/var/log
 
 # Copy the binary, config file and man page into the env.
-cp ${BINARY} package_build${BINFIX}/bin
+cp ${BINARY}.macos package_build${BINFIX}/bin/${BINARY}
 cp *.1.gz package_build${BINFIX}/share/man/man1
 cp examples/up.conf.example package_build${PREFIX}/etc/${BINARY}/
 
@@ -38,4 +38,8 @@ fpm -s dir -t osxpkg \
   --version ${VERSION} \
   --after-install scripts/after-install-osx.sh \
   --osxpkg-identifier-prefix com.github.davidnewhall \
+  --license MIT \
+  --maintainer 'david at sleepers dot pro' \
+  --url 'https://github.com/davidnewhall/unifi-poller' \
+  --description 'This daemon polls a Unifi controller at a short interval and stores the collected metric data in an Influx Database.' \
   --chdir package_build


### PR DESCRIPTION
- Make the Makefile more makefile-like by avoiding rebuilding assets.
  - Tag assets with their name. 
- Makes `make clean` a little cleaner too. 
- Avoids running `make clean` automatically. 
  - If you want to rebuild, run `make clean` first.