### PR TITLE
Add site metrics to influxdb.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:fda9365965d38b80007d47efbf516adbc65d266515f263e9c43336ab47ef0f69"
+  digest = "1:f42822e830b569d8527ad6e57585e6ccc094296bc9d648ccd256f95249453ce1"
   name = "github.com/golift/unifi"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1d74eaae61aad0558126b6ade64753ebcc5982ef"
-  version = "v2.0.4"
+  revision = "fc5a69d27d7527038ae55ee5112bc755db380879"
+  version = "v2.1.0"
 
 [[projects]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,24 @@
 Collect your Unifi Controller Data and send it to an InfluxDB instance.
 Grafana dashboards included. Updated 2019.
 
+## Description
+
+Ubiquiti makes networking devices like switches, gateways (routers) and wireless
+access points. They have a line of equipment named UniFi that uses a controller
+to keep stats and make it easy to configure the network devices. This controller
+can be installed on Windows, macOS and Linux. Ubiquiti also provides a dedicated
+hardware devices called a CloudKey that runs the controller software.
+
+Unifi-Poller is a smaller application that runs on macOS, Linux or Docker. It
+polls your controller every 30 seconds for metric data and stores that data in
+an Influx Database. A small setup with 2 APs, 1 switch, 1 gateway and 40 clients
+produces nearly 3000 fields (metrics).
+
+This application requires your controller to be running all the time. If you run
+a Unifi Controller, there's no excuse not to install Influx, Grafana and this app.
+You'll have a plethora of data at your fingertips and the ability to craft custom
+graphs to slice the data any way you choose. Good luck!
+
 ## Installation
 
 [See the Wiki!](https://github.com/davidnewhall/unifi-poller/wiki/Installation)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Grafana dashboards included. Updated 2019.
 
 ## Description
 
-Ubiquiti makes networking devices like switches, gateways (routers) and wireless
-access points. They have a line of equipment named UniFi that uses a controller
-to keep stats and make it easy to configure the network devices. This controller
-can be installed on Windows, macOS and Linux. Ubiquiti also provides a dedicated
-hardware devices called a CloudKey that runs the controller software.
+[Ubiquiti](https://www.ui.com) makes networking devices like switches, gateways
+(routers) and wireless access points. They have a line of equipment named
+[UniFi](https://www.ui.com/products/#unifi) that uses a
+[controller](https://www.ui.com/download/unifi/) to keep stats and network
+device configuration This controller can be installed on Windows, macOS and Linux.
+Ubiquiti also provides a dedicated hardware devices called a CloudKey that runs
+the controller software.
 
 Unifi-Poller is a smaller application that runs on macOS, Linux or Docker. It
 polls your controller every 30 seconds for metric data and stores that data in
@@ -17,7 +19,9 @@ an Influx Database. A small setup with 2 APs, 1 switch, 1 gateway and 40 clients
 produces nearly 3000 fields (metrics).
 
 This application requires your controller to be running all the time. If you run
-a Unifi Controller, there's no excuse not to install Influx, Grafana and this app.
+a Unifi Controller, there's no excuse not to install
+[Influx](https://github.com/davidnewhall/unifi-poller/wiki/InfluxDB),
+[Grafana](https://github.com/davidnewhall/unifi-poller/wiki/Grafana) and this app.
 You'll have a plethora of data at your fingertips and the ability to craft custom
 graphs to slice the data any way you choose. Good luck!
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Grafana dashboards included. Updated 2019.
 [Ubiquiti](https://www.ui.com) makes networking devices like switches, gateways
 (routers) and wireless access points. They have a line of equipment named
 [UniFi](https://www.ui.com/products/#unifi) that uses a
-[controller](https://www.ui.com/download/unifi/) to keep stats and network
-device configuration This controller can be installed on Windows, macOS and Linux.
-Ubiquiti also provides a dedicated hardware devices called a CloudKey that runs
-the controller software.
+[controller](https://www.ui.com/download/unifi/) to keep stats and simplify network
+device configuration. This controller can be installed on Windows, macOS and Linux.
+Ubiquiti also provides a dedicated hardware device called a
+[CloudKey](https://www.ui.com/unifi/unifi-cloud-key/) that runs the controller software.
 
 Unifi-Poller is a smaller application that runs on macOS, Linux or Docker. It
 polls your controller every 30 seconds for metric data and stores that data in

--- a/pkg/unifi-poller/config.go
+++ b/pkg/unifi-poller/config.go
@@ -1,6 +1,7 @@
 package unifipoller
 
 import (
+	"strings"
 	"time"
 
 	"github.com/golift/unifi"
@@ -39,6 +40,14 @@ type UnifiPoller struct {
 	*Config
 }
 
+// Metrics contains all the data from the controller.
+type Metrics struct {
+	unifi.Sites
+	unifi.Clients
+	*unifi.Devices
+	influx.BatchPoints
+}
+
 // Config represents the data needed to poll a controller and report to influxdb.
 type Config struct {
 	Interval   Dur      `json:"interval,_omitempty" toml:"interval,_omitempty" xml:"interval" yaml:"interval"`
@@ -60,7 +69,7 @@ type Dur struct{ value time.Duration }
 
 // UnmarshalTOML parses a duration type from a config file.
 func (v *Dur) UnmarshalTOML(data []byte) error {
-	unquoted := string(data[1 : len(data)-1])
+	unquoted := strings.Trim(string(data), `"`)
 	dur, err := time.ParseDuration(unquoted)
 	if err == nil {
 		v.value = dur

--- a/pkg/unifi-poller/unifi.go
+++ b/pkg/unifi-poller/unifi.go
@@ -40,95 +40,100 @@ FIRST:
 func (u *UnifiPoller) PollController() {
 	log.Println("[INFO] Everything checks out! Poller started, interval:", u.Interval.value)
 	ticker := time.NewTicker(u.Interval.value)
-
+	var err error
 	for range ticker.C {
+		m := &Metrics{}
 		// Get the sites we care about.
-		sites, err := u.filterSites(u.Sites)
-		if err != nil {
+		if m.Sites, err = u.GetFilteredSites(); err != nil {
 			logErrors([]error{err}, "uni.GetSites()")
 		}
 		// Get all the points.
-		clients, err := u.GetClients(sites)
-		if err != nil {
+		if m.Clients, err = u.GetClients(m.Sites); err != nil {
 			logErrors([]error{err}, "uni.GetClients()")
 		}
-		devices, err := u.GetDevices(sites)
-		if err != nil {
+		if m.Devices, err = u.GetDevices(m.Sites); err != nil {
 			logErrors([]error{err}, "uni.GetDevices()")
 		}
+
 		// Make a new Points Batcher.
-		bp, err := influx.NewBatchPoints(influx.BatchPointsConfig{Database: u.InfluxDB})
+		m.BatchPoints, err = influx.NewBatchPoints(influx.BatchPointsConfig{Database: u.InfluxDB})
 		if err != nil {
 			logErrors([]error{err}, "influx.NewBatchPoints")
 			continue
 		}
 		// Batch (and send) all the points.
-		if errs := batchPoints(devices, clients, bp); errs != nil && hasErr(errs) {
+		if errs := m.SendPoints(); errs != nil && hasErr(errs) {
 			logErrors(errs, "asset.Points()")
 		}
-		if err := u.Write(bp); err != nil {
+		if err := u.Write(m.BatchPoints); err != nil {
 			logErrors([]error{err}, "infdb.Write(bp)")
 		}
 
 		// Talk about the data.
 		var fieldcount, pointcount int
-		for _, p := range bp.Points() {
+		for _, p := range m.Points() {
 			pointcount++
 			i, _ := p.Fields()
 			fieldcount += len(i)
 		}
-		u.Logf("Unifi Measurements Recorded. Sites: %d Clients: %d, "+
+		u.Logf("Unifi Measurements Recorded. Sites: %d, Clients: %d, "+
 			"Wireless APs: %d, Gateways: %d, Switches: %d, Points: %d, Fields: %d",
-			len(sites), len(clients.UCLs),
-			len(devices.UAPs), len(devices.USGs), len(devices.USWs), pointcount, fieldcount)
+			len(m.Sites), len(m.Clients), len(m.UAPs), len(m.USGs), len(m.USWs), pointcount, fieldcount)
 	}
 }
 
-// batchPoints combines all device and client data into influxdb data points.
-func batchPoints(devices *unifi.Devices, clients *unifi.Clients, bp influx.BatchPoints) (errs []error) {
-	process := func(asset Asset) error {
-		if asset == nil {
-			return nil
-		}
-		influxPoints, err := asset.Points()
-		if err != nil {
-			return err
-		}
-		bp.AddPoints(influxPoints)
-		return nil
+// SendPoints combines all device and client data into influxdb data points.
+// Call this after you've collected all the data you care about.
+// This sends all the batched points to InfluxDB.
+func (m *Metrics) SendPoints() (errs []error) {
+	for _, asset := range m.Sites {
+		errs = append(errs, m.processPoints(asset))
 	}
-	if devices != nil {
-		for _, asset := range devices.UAPs {
-			errs = append(errs, process(asset))
-		}
-		for _, asset := range devices.USGs {
-			errs = append(errs, process(asset))
-		}
-		for _, asset := range devices.USWs {
-			errs = append(errs, process(asset))
-		}
+	for _, asset := range m.Clients {
+		errs = append(errs, m.processPoints(asset))
 	}
-	if clients != nil {
-		for _, asset := range clients.UCLs {
-			errs = append(errs, process(asset))
-		}
+	if m.Devices == nil {
+		return
+	}
+	for _, asset := range m.UAPs {
+		errs = append(errs, m.processPoints(asset))
+	}
+	for _, asset := range m.USGs {
+		errs = append(errs, m.processPoints(asset))
+	}
+	for _, asset := range m.USWs {
+		errs = append(errs, m.processPoints(asset))
 	}
 	return
 }
 
-// filterSites returns a list of sites to fetch data for.
-// Omits requested but unconfigured sites.
-func (u *UnifiPoller) filterSites(filter []string) ([]unifi.Site, error) {
+// processPoints is helper function for SendPoints.
+func (m *Metrics) processPoints(asset Asset) error {
+	if asset == nil {
+		return nil
+	}
+	influxPoints, err := asset.Points()
+	if err != nil || influxPoints == nil {
+		return err
+	}
+	m.BatchPoints.AddPoints(influxPoints)
+	return nil
+}
+
+// GetFilteredSites returns a list of sites to fetch data for.
+// Omits requested but unconfigured sites. Grabs the full list from the
+// controller and filters the sites provided in the config file.
+func (u *UnifiPoller) GetFilteredSites() (unifi.Sites, error) {
 	sites, err := u.GetSites()
 	if err != nil {
 		return nil, err
-	} else if len(filter) < 1 || StringInSlice("all", filter) {
+	} else if len(u.Sites) < 1 || StringInSlice("all", u.Sites) {
 		return sites, nil
 	}
 	var i int
 	for _, s := range sites {
 		// Only include valid sites in the request filter.
-		if StringInSlice(s.Name, filter) {
+		if StringInSlice(s.Name, u.Sites) {
 			sites[i] = s
 			i++
 		}

--- a/pkg/unifi-poller/unifi.go
+++ b/pkg/unifi-poller/unifi.go
@@ -112,11 +112,11 @@ func (m *Metrics) processPoints(asset Asset) error {
 	if asset == nil {
 		return nil
 	}
-	influxPoints, err := asset.Points()
-	if err != nil || influxPoints == nil {
+	points, err := asset.Points()
+	if err != nil || points == nil {
 		return err
 	}
-	m.BatchPoints.AddPoints(influxPoints)
+	m.BatchPoints.AddPoints(points)
 	return nil
 }
 

--- a/pkg/unifi-poller/unifipoller.go
+++ b/pkg/unifi-poller/unifipoller.go
@@ -101,7 +101,11 @@ func (u *UnifiPoller) GetUnifi() (err error) {
 	if u.Debug && !u.Quiet {
 		u.Unifi.DebugLog = log.Printf // Log debug messages.
 	}
-	u.Logf("Authenticated to Unifi Controller at %s as user %s", u.UnifiBase, u.UnifiUser)
+	v, err := u.GetServer()
+	if err != nil {
+		v.ServerVersion = "unknown"
+	}
+	u.Logf("Authenticated to Unifi Controller at %s version %s as user %s", u.UnifiBase, v.ServerVersion, u.UnifiUser)
 	if err = u.CheckSites(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This contribution adds metric data for Unifi Controller Sites. These measurements are recorded to a new `subsystems` table. This seems to refer to the networks configured for each site.

Also added is the controller version output (on startup). You can now dump the json payload for any API path. Try it out: 
`unifi-poller -j "other /api/stat/sites" | jq`