### PR TITLE
Dashboard Updates

### DIFF
--- a/examples/unifi-clients-grafana-dash.json
+++ b/examples/unifi-clients-grafana-dash.json
@@ -64,7 +64,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1560917275243,
+  "iteration": 1560917693674,
   "links": [
     {
       "icon": "external link",
@@ -2903,5 +2903,5 @@
   "timezone": "",
   "title": "UniFi Client Insights",
   "uid": "YVR23BZiz",
-  "version": 8
+  "version": 55
 }

--- a/examples/unifi-clients-grafana-dash.json
+++ b/examples/unifi-clients-grafana-dash.json
@@ -20,7 +20,7 @@
       "type": "panel",
       "id": "grafana-piechart-panel",
       "name": "Pie Chart",
-      "version": "1.3.3"
+      "version": "1.3.6"
     },
     {
       "type": "panel",
@@ -64,7 +64,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1559898655544,
+  "iteration": 1560917275243,
   "links": [
     {
       "icon": "external link",
@@ -784,7 +784,7 @@
       "strokeWidth": "3",
       "targets": [
         {
-          "alias": "$tag_ap_mac / $tag_radio_proto / $tag_radio / $tag_radio_name",
+          "alias": "$tag_radio_proto",
           "groupBy": [
             {
               "params": [
@@ -796,7 +796,7 @@
           "measurement": "clients",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "select count(distinct(hostname)) FROM \"clients\" WHERE (time > now() - 10m AND ap_mac =~ /$AP$/ AND \"site_name\" =~ /$Site$/ and  \"name\" =~ /^$Client$/) group by radio_proto, radio, radio_name, ap_mac",
+          "query": "SELECT count(distinct(\"hostname\")) FROM \"clients\" WHERE \"is_wired\" != 'true' AND $timeFilter  AND \"site_name\" =~ /$Site$/  AND \"name\" =~ /^$Client$/ GROUP BY radio_proto",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -817,14 +817,14 @@
           "tags": [
             {
               "key": "is_wired",
-              "operator": "=",
-              "value": "false"
+              "operator": "!=",
+              "value": "true"
             }
           ]
         }
       ],
       "timeFrom": null,
-      "title": "AP Radio / Clients",
+      "title": "Clients / AP Radio",
       "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
@@ -2903,5 +2903,5 @@
   "timezone": "",
   "title": "UniFi Client Insights",
   "uid": "YVR23BZiz",
-  "version": 54
+  "version": 8
 }

--- a/examples/unifi-sites-grafana-dash.json
+++ b/examples/unifi-sites-grafana-dash.json
@@ -65,7 +65,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1560630117335,
+  "iteration": 1560916503572,
   "links": [
     {
       "icon": "external link",
@@ -2789,6 +2789,8 @@
           "measurement": "subsystems",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT max(\"rx_bytes-r\") AS \"Bytes RX\", max(\"tx_bytes-r\") AS \"Bytes TX\" FROM \"subsystems\" WHERE (\"site_name\" =~ /^$site$/) AND $timeFilter GROUP BY time($__interval), \"subsystem\" fill(null)",
+          "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -2842,7 +2844,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Site $Site Data Transfer",
+      "title": "Site $site Data Transfer",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -3021,7 +3023,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Site $Site Client Counts",
+      "title": "Site $site Client Counts",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -3073,7 +3075,7 @@
         "datasource": "${DS_UNIFI}",
         "definition": "show tag values from \"subsystems\" with key=\"site_name\"",
         "hide": 2,
-        "includeAll": false,
+        "includeAll": true,
         "label": "",
         "multi": false,
         "name": "site",
@@ -3082,7 +3084,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -3143,5 +3145,5 @@
   "timezone": "",
   "title": "Unifi Sites",
   "uid": "5_omrT7Zz",
-  "version": 26
+  "version": 36
 }


### PR DESCRIPTION
Fixes `site` dashboard: repeating panels work now. Closes #45.
Makes a small change to 1 graph in `uap` dashboard.
