### PR TITLE
Fix home-brew formula build. Better logging. Exit on error.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:11e7c0f12739f8ddebb72d8555d5d336f2121fd5c7d9f5909763e918947a5232"
+  digest = "1:28ef1378055e34f154c8efcd8863a3e53a276c58cc7fc0d0a32d6b9eed6f6cfc"
   name = "github.com/golift/unifi"
   packages = ["."]
   pruneopts = "UT"
-  revision = "facbb7d0e5db951c7074504188fcfc13cca6d5b2"
-  version = "v2.1.2"
+  revision = "c610e15131f93950f7aa6e9c564a86d896b8b437"
+  version = "v2.1.3"
 
 [[projects]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ check_fpm:
 formula: $(BINARY).rb
 v$(VERSION).tar.gz.sha256:
 	# Calculate the SHA from the Github source file.
-	curl -sL $(URL)/archive/v$(VERSION).tar.gz | openssl dgst -sha256 | tee v$(VERSION).tar.gz.sha256
+	curl -sL $(URL)/archive/v$(VERSION).tar.gz | openssl dgst -r -sha256 | tee v$(VERSION).tar.gz.sha256
 $(BINARY).rb: v$(VERSION).tar.gz.sha256
 	# Creating formula from template using sed.
-	sed "s/{{Version}}/$(VERSION)/g;s/{{SHA256}}/$$(<v$(VERSION).tar.gz.sha256)/g;s/{{Desc}}/$(DESC)/g;s%{{URL}}%$(URL)%g" templates/$(BINARY).rb.tmpl | tee $(BINARY).rb
+	sed "s/{{Version}}/$(VERSION)/g;s/{{SHA256}}/`head -c64 v$(VERSION).tar.gz.sha256`/g;s/{{Desc}}/$(DESC)/g;s%{{URL}}%$(URL)%g" templates/$(BINARY).rb.tmpl | tee $(BINARY).rb
 
 # Extras
 

--- a/cmd/unifi-poller/README.md
+++ b/cmd/unifi-poller/README.md
@@ -26,13 +26,15 @@ This daemon polls a Unifi controller at a short interval and stores the collecte
     -j, --dumpjson <filter>
         This is a debug option; use this when you are missing data in your graphs,
         and/or you want to inspect the raw data coming from the controller. The
-        filter only accepts two options: devices or clients. This will print a lot
-        of information. Recommend piping it into a file and/or into jq for better
-        visualization. This requires a valid config file that; one that contains
+        filter accepts three options: devices, clients, other. This will print a
+        lot of information. Recommend piping it into a file and/or into jq for
+        better visualization. This requires a valid config file that contains
         working authentication details for a Unifi Controller. This only dumps
         data for sites listed in the config file. The application exits after
         printing the JSON payload; it does not daemonize or report to InfluxDB
-        with this option.
+        with this option. The `other` option is special. This allows you request
+        any api path. It must be enclosed in quotes with the word other. Example:
+           unifi-poller -j "other /stat/admins"
 
     -h, --help
         Display usage and exit.
@@ -62,6 +64,18 @@ This daemon polls a Unifi controller at a short interval and stores the collecte
         Setting this to true will turn off per-device and per-interval logs. Only
         errors will be logged. Using this with debug=true adds line numbers to
         any error logs.
+
+    `max_errors`     default: 0
+        If you restart the UniFI controller, the poller will lose access until
+        it is restarted. Specifying a number greater than -1 for max_errors will
+        cause the poller to exit when it reaches the error count specified.
+        This problematic condition can be triggered by InfluxDB having issues
+        too. Generally only 1 error per interval is created, but if more than one
+        backend is having issues > 1 error could be generated per interval. Once
+        the poller exits, it is expected that something will restart it
+        automatically so it gets back in line; something is usually systemd,
+        docker or launchd. The default setting of 0 will cause an exit after
+        just 1 error. Recommended values are 0-5.
 
     `influx_url`     default: http://127.0.0.1:8086
         This is the URL where the Influx web server is available.

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -18,6 +18,12 @@
 # Recommend using debug with this setting for better error logging.
 #quiet = false
 
+# If the poller experiences an error from the Unifi Controller or from InfluxDB
+# it will exit. If you do not want it to exit, change max_errors to -1. You can
+# adjust the config to tolerate more errors by setting this to a higher value.
+# Recommend setting this between 0 and 5. See man page for more explanation.
+#max_errors = 0
+
 # InfluxDB does not require auth by default, so the user/password are probably unimportant.
 #influx_url = "http://127.0.0.1:8086"
 #influx_user = "unifi"

--- a/init/launchd/com.github.davidnewhall.unifi-poller.plist
+++ b/init/launchd/com.github.davidnewhall.unifi-poller.plist
@@ -15,8 +15,8 @@
         <key>KeepAlive</key>
         <true/>
         <key>StandardErrorPath</key>
-        <string>/usr/local/var/log/unifi-poller/log</string>
+        <string>/usr/local/var/log/unifi-poller.log</string>
         <key>StandardOutPath</key>
-        <string>/usr/local/var/log/unifi-poller/log</string>
+        <string>/usr/local/var/log/unifi-poller.log</string>
     </dict>
 </plist>

--- a/pkg/unifi-poller/config.go
+++ b/pkg/unifi-poller/config.go
@@ -35,6 +35,7 @@ type UnifiPoller struct {
 	DumpJSON   string
 	ShowVer    bool
 	Flag       *pflag.FlagSet
+	errorCount int
 	influx.Client
 	*unifi.Unifi
 	*Config
@@ -50,6 +51,7 @@ type Metrics struct {
 
 // Config represents the data needed to poll a controller and report to influxdb.
 type Config struct {
+	MaxErrors  int      `json:"max_errors,_omitempty" toml:"max_errors,_omitempty" xml:"max_errors" yaml:"max_errors"`
 	Interval   Dur      `json:"interval,_omitempty" toml:"interval,_omitempty" xml:"interval" yaml:"interval"`
 	Debug      bool     `json:"debug" toml:"debug" xml:"debug" yaml:"debug"`
 	Quiet      bool     `json:"quiet,_omitempty" toml:"quiet,_omitempty" xml:"quiet" yaml:"quiet"`

--- a/pkg/unifi-poller/helpers.go
+++ b/pkg/unifi-poller/helpers.go
@@ -15,11 +15,13 @@ func hasErr(errs []error) bool {
 	return false
 }
 
-// logErrors writes a slice of errors, with a prefix, to log-out.
-func logErrors(errs []error, prefix string) {
+// LogErrors writes a slice of errors, with a prefix, to log-out.
+// It also incriments the error counter.
+func (u *UnifiPoller) LogErrors(errs []error, prefix string) {
 	for _, err := range errs {
 		if err != nil {
-			log.Println("[ERROR]", prefix+":", err.Error())
+			u.errorCount++
+			log.Printf("[ERROR] (%v/%v) %v: %v", prefix, err.Error(), u.errorCount, u.MaxErrors)
 		}
 	}
 }
@@ -35,8 +37,8 @@ func StringInSlice(str string, slc []string) bool {
 }
 
 // Logf prints a log entry if quiet is false.
-func (c *Config) Logf(m string, v ...interface{}) {
-	if !c.Quiet {
+func (u *UnifiPoller) Logf(m string, v ...interface{}) {
+	if !u.Quiet {
 		log.Printf("[INFO] "+m, v...)
 	}
 }

--- a/pkg/unifi-poller/helpers.go
+++ b/pkg/unifi-poller/helpers.go
@@ -21,7 +21,7 @@ func (u *UnifiPoller) LogErrors(errs []error, prefix string) {
 	for _, err := range errs {
 		if err != nil {
 			u.errorCount++
-			log.Printf("[ERROR] (%v/%v) %v: %v", prefix, err.Error(), u.errorCount, u.MaxErrors)
+			log.Printf("[ERROR] (%v/%v) %v: %v", u.errorCount, u.MaxErrors, prefix, err.Error())
 		}
 	}
 }

--- a/pkg/unifi-poller/helpers.go
+++ b/pkg/unifi-poller/helpers.go
@@ -16,7 +16,7 @@ func hasErr(errs []error) bool {
 }
 
 // LogErrors writes a slice of errors, with a prefix, to log-out.
-// It also incriments the error counter.
+// It also increments the error counter.
 func (u *UnifiPoller) LogErrors(errs []error, prefix string) {
 	for _, err := range errs {
 		if err != nil {

--- a/pkg/unifi-poller/helpers.go
+++ b/pkg/unifi-poller/helpers.go
@@ -1,6 +1,7 @@
 package unifipoller
 
 import (
+	"fmt"
 	"log"
 	"strings"
 )
@@ -21,7 +22,7 @@ func (u *UnifiPoller) LogErrors(errs []error, prefix string) {
 	for _, err := range errs {
 		if err != nil {
 			u.errorCount++
-			log.Printf("[ERROR] (%v/%v) %v: %v", u.errorCount, u.MaxErrors, prefix, err.Error())
+			_ = log.Output(2, fmt.Sprintf("[ERROR] (%v/%v) %v: %v", u.errorCount, u.MaxErrors, prefix, err))
 		}
 	}
 }
@@ -39,6 +40,18 @@ func StringInSlice(str string, slc []string) bool {
 // Logf prints a log entry if quiet is false.
 func (u *UnifiPoller) Logf(m string, v ...interface{}) {
 	if !u.Quiet {
-		log.Printf("[INFO] "+m, v...)
+		_ = log.Output(2, fmt.Sprintf("[INFO] "+m, v...))
 	}
+}
+
+// LogDebugf prints a debug log entry if debug is true and quite is false
+func (u *UnifiPoller) LogDebugf(m string, v ...interface{}) {
+	if u.Debug && !u.Quiet {
+		_ = log.Output(2, fmt.Sprintf("[DEBUG] "+m, v...))
+	}
+}
+
+// LogErrorf prints an error log entry.
+func (u *UnifiPoller) LogErrorf(m string, v ...interface{}) {
+	_ = log.Output(2, fmt.Sprintf("[ERROR] "+m, v...))
 }

--- a/pkg/unifi-poller/poller.go
+++ b/pkg/unifi-poller/poller.go
@@ -61,7 +61,7 @@ func (u *UnifiPoller) Run() (err error) {
 	}
 	if log.SetFlags(0); u.Debug {
 		log.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
-		log.Println("[DEBUG] Debug Logging Enabled")
+		u.LogDebugf("Debug Logging Enabled")
 	}
 	log.Printf("[INFO] Unifi-Poller v%v Starting Up! PID: %d", Version, os.Getpid())
 
@@ -95,11 +95,8 @@ func (u *UnifiPoller) GetUnifi() (err error) {
 	if err != nil {
 		return errors.Wrap(err, "unifi controller")
 	}
-	u.Unifi.ErrorLog = log.Printf // Log all errors.
-	// Doing it this way allows debug error logs (line numbers, etc)
-	if u.Debug && !u.Quiet {
-		u.Unifi.DebugLog = log.Printf // Log debug messages.
-	}
+	u.Unifi.ErrorLog = u.LogErrorf // Log all errors.
+	u.Unifi.DebugLog = u.LogDebugf // Log debug messages.
 	v, err := u.GetServer()
 	if err != nil {
 		v.ServerVersion = "unknown"

--- a/pkg/unifi-poller/unifipoller.go
+++ b/pkg/unifi-poller/unifipoller.go
@@ -50,7 +50,7 @@ func (u *UnifiPoller) GetConfig() error {
 	if u.DumpJSON != "" {
 		u.Quiet = true
 	}
-	u.Config.Logf("Loaded Configuration: %s", u.ConfigFile)
+	u.Logf("Loaded Configuration: %s", u.ConfigFile)
 	return nil
 }
 
@@ -71,8 +71,7 @@ func (u *UnifiPoller) Run() (err error) {
 	if err = u.GetInfluxDB(); err != nil {
 		return err
 	}
-	u.PollController()
-	return nil
+	return u.PollController()
 }
 
 // GetInfluxDB returns an influxdb interface.

--- a/templates/unifi-poller.rb.tmpl
+++ b/templates/unifi-poller.rb.tmpl
@@ -25,7 +25,7 @@ class UnifiPoller < Formula
       # If this fails, the user gets a nice big warning about write permissions on their
       # [/usr/local/]var/log folder. The alternative could be letting the app silently
       # fail to start when it cannot write logs. This is better. Fix perms; reinstall.
-      system "mkdir", "-p", "#{var}/log/unifi-poller"
+      system "touch", "#{var}/log/unifi-poller.log"
     end
   end
   def caveats
@@ -33,7 +33,7 @@ class UnifiPoller < Formula
   This application will not work until the config file has authentication
   information for a Unifi Controller and an Influx Database. Edit the config
   file at #{etc}/unifi-poller/up.conf then start the application with
-  brew services start unifi-poller ~ log file: #{var}/log/unifi-poller/log
+  brew services start unifi-poller ~ log file: #{var}/log/unifi-poller.log
   The manual explains the config file options: man unifi-poller
     EOS
   end
@@ -56,9 +56,9 @@ class UnifiPoller < Formula
            <key>KeepAlive</key>
            <true/>
            <key>StandardErrorPath</key>
-           <string>#{var}/log/unifi-poller/log</string>
+           <string>#{var}/log/unifi-poller.log</string>
            <key>StandardOutPath</key>
-           <string>#{var}/log/unifi-poller/log</string>
+           <string>#{var}/log/unifi-poller.log</string>
        </dict>
    </plist>
    EOS


### PR DESCRIPTION
- Fix home-brew formula build.
- Better logging (with correct line numbers).
- New feature to exit when errors occur (so the app can re-authenticate to the controller).
- Move raw json lookup to [unifi](https://github.com/golift/unifi/pull/15) library.
- Update man page.
- Change log file location on macOS. again.