### PR TITLE
Allow config file in xml, json and yaml in addition to default toml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /up.conf
 /unifi-poller
 /unifi-poller*.gz
+/unifi-poller*.zip
 /unifi-poller*.1
 /unifi-poller*.deb
 /unifi-poller*.rpm
+/unifi-poller.exe
 /unifi-poller.macos
 /unifi-poller.linux
 /unifi-poller.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 - docker run -d --name unifi-poller golift/unifi-poller | tee docker_id
   # Once we figure out how to keep it running we can remove the -a in ps args.
 - docker ps -a | grep -q unifi-poller
-- docker logs $(<docker_id) 2>&1 | grep -Eq "Loaded Configuration[:] /etc/unifi-poller/up.conf"
+- docker logs $(<docker_id) 2>&1 | grep -Eq "Loading Configuration File[:] /etc/unifi-poller/up.conf"
 # test and build everything
 - rvm 2.0.0 do make release
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ after_success:
   - ls -l release/
   - |
       declare -r SSH_FILE="$(mktemp -u $HOME/.ssh/XXXXX)"
-
       echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
       # Get deploy key for golift/homebrew-mugs.
       openssl aes-256-cbc -K $encrypted_9f3147001275_key -iv $encrypted_9f3147001275_iv -in ".travis/github_deploy_key.enc" -out "$SSH_FILE" -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ script:
 # test and build everything
 - rvm 2.0.0 do make release
 after_success:
+  # Display Release Folder
+  - ls -l release/
   - |
       declare -r SSH_FILE="$(mktemp -u $HOME/.ssh/XXXXX)"
-      # Display Release Folder
-      ls -l release/
+
       echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
       # Get deploy key for golift/homebrew-mugs.
       openssl aes-256-cbc -K $encrypted_9f3147001275_key -iv $encrypted_9f3147001275_iv -in ".travis/github_deploy_key.enc" -out "$SSH_FILE" -d

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:28ef1378055e34f154c8efcd8863a3e53a276c58cc7fc0d0a32d6b9eed6f6cfc"
   name = "github.com/golift/unifi"
   packages = ["."]
@@ -22,25 +30,6 @@
   revision = "8ff2fc3824fcb533795f9a2f233275f0bb18d6c5"
 
 [[projects]]
-  digest = "1:b56c589214f01a5601e0821387db484617392d0042f26234bf2da853a2f498a1"
-  name = "github.com/naoina/go-stringutil"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "6b638e95a32d0c1131db0e7fe83775cbea4a0d0b"
-  version = "v0.1.0"
-
-[[projects]]
-  digest = "1:f58c3d0e46b64878d00652fedba24ee879725191ab919dca7b62586859281c04"
-  name = "github.com/naoina/toml"
-  packages = [
-    ".",
-    "ast",
-  ]
-  pruneopts = "UT"
-  revision = "e6f5723bf2a66af014955e0888881314cf294129"
-  version = "v0.1.1"
-
-[[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -56,15 +45,24 @@
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
+[[projects]]
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/BurntSushi/toml",
     "github.com/golift/unifi",
     "github.com/influxdata/influxdb1-client/v2",
-    "github.com/naoina/toml",
     "github.com/pkg/errors",
     "github.com/spf13/pflag",
+    "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,10 +24,6 @@
 #   go-tests = true
 #   unused-packages = true
 
-[[constraint]]
-  name = "github.com/naoina/toml"
-  version = "0.1.1"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/cmd/unifi-poller/start.go
+++ b/cmd/unifi-poller/start.go
@@ -9,6 +9,7 @@ import (
 )
 
 func main() {
+	log.SetFlags(log.LstdFlags)
 	unifi := &unifipoller.UnifiPoller{}
 	if unifi.ParseFlags(os.Args[1:]); unifi.ShowVer {
 		fmt.Printf("unifi-poller v%s\n", unifipoller.Version)

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,4 +14,6 @@ new benefits to the existing dashboards. When that happens I update them.
 Keeping an Example set allows you to update too, inspect the changes, and apply them
 to your own custom dashboards.
 
-This folder also contains an example configuration file and some dashboard screenshots.
+This folder also contains dashboard screenshots and example configuration files in four supported formats.
+You can use any format you want for the config file, just give it the appropriate prefix for the format.
+ie. an xml file should end with `.xml`.

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -9,7 +9,7 @@
  "influx_pass": "unifi",
  "influx_db": "unifi",
  "unifi_user": "influxdb",
- "unifi_pass": "4BB9345C-2341-48D7-99F5-E01B583FF77F",
+ "unifi_pass": "",
  "unifi_url": "https://127.0.0.1:8443",
  "verify_ssl": false
 }

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -1,0 +1,15 @@
+{
+ "sites": ["default"],
+ "interval": "30s",
+ "debug": false,
+ "quiet": false,
+ "max_errors": 0,
+ "influx_url": "http://127.0.0.1:8086",
+ "influx_user": "unifi",
+ "influx_pass": "unifi",
+ "influx_db": "unifi",
+ "unifi_user": "influxdb",
+ "unifi_pass": "4BB9345C-2341-48D7-99F5-E01B583FF77F",
+ "unifi_url": "https://127.0.0.1:8443",
+ "verify_ssl": false
+}

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -1,15 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+########################################################
+# unifi-poller primary configuration file. XML FORMAT #
+# provided values are defaults                         #
+########################################################
+-->
+
+<!--
+If the controller has more than one site, specify which sites to poll here.
+If only one site, "default" is likely the correct name.
+Set this to ["all"] to poll all sites, no matter their names.
+Add more sites by adding additional lines:
+<sites>site1</sites>
+<sites>site2</sites>
+-->
+<sites>default</sites>
+
+<!--
+The Unifi Controller only updates traffic stats about every 30 seconds.
+Setting this to something lower may lead to "zeros" in your data. You've been warned.
+-->
+<interval>30s</interval>
+
+<!-- Turns on line numbers, microsecond logging, and a per-device log. -->
 <debug>false</debug>
+
+<!--
+Turns off per-device log and per-interval log. Logs only errors.
+Recommend using debug with this setting for better error logging.
+-->
+<quiet>false</quiet>
+
+<!--
+# If the poller experiences an error from the Unifi Controller or from InfluxDB
+# it will exit. If you do not want it to exit, change max_errors to -1. You can
+# adjust the config to tolerate more errors by setting this to a higher value.
+# Recommend setting this between 0 and 5. See man page for more explanation.
+-->
+<max_errors>0</max_errors>
+
+<!-- InfluxDB does not require auth by default, so the user/password are probably unimportant. -->
 <influx_db>unifi</influx_db>
 <influx_pass>unifi</influx_pass>
 <influx_url>http://127.0.0.1:8086</influx_url>
 <influx_user>unifi</influx_user>
-<interval>30s</interval>
-<max_errors>0</max_errors>
-<quiet>false</quiet>
-<sites>default</sites>
-<sites>site2</sites>
-<unifi_pass>4BB9345C-2341-48D7-99F5-E01B583FF77F</unifi_pass>
-<unifi_url>https://127.0.0.1:8443</unifi_url>
+
+
+<!-- Make a read-only user in the Unifi Admin Settings. -->
 <unifi_user>influxdb</unifi_user>
+<unifi_pass></unifi_pass>
+<unifi_url>https://127.0.0.1:8443</unifi_url>
+<!--
+If your Unifi controller has a valid SSL certificate, you can enable
+this option to validate it. Otherwise, any SSL certificate is valid.
+-->
 <verify_ssl>false</verify_ssl>

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -7,9 +7,8 @@
 <interval>30s</interval>
 <max_errors>0</max_errors>
 <quiet>false</quiet>
-<sites>
-  <element>default</element>
-</sites>
+<sites>default</sites>
+<sites>site2</sites>
 <unifi_pass>4BB9345C-2341-48D7-99F5-E01B583FF77F</unifi_pass>
 <unifi_url>https://127.0.0.1:8443</unifi_url>
 <unifi_user>influxdb</unifi_user>

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<debug>false</debug>
+<influx_db>unifi</influx_db>
+<influx_pass>unifi</influx_pass>
+<influx_url>http://127.0.0.1:8086</influx_url>
+<influx_user>unifi</influx_user>
+<interval>30s</interval>
+<max_errors>0</max_errors>
+<quiet>false</quiet>
+<sites>
+  <element>default</element>
+</sites>
+<unifi_pass>4BB9345C-2341-48D7-99F5-E01B583FF77F</unifi_pass>
+<unifi_url>https://127.0.0.1:8443</unifi_url>
+<unifi_user>influxdb</unifi_user>
+<verify_ssl>false</verify_ssl>

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -5,53 +5,55 @@
 # provided values are defaults                         #
 ########################################################
 -->
+<unifi-poller>
+  <!--
+  If the controller has more than one site, specify which sites to poll here.
+  If only one site, "default" is likely the correct name.
+  Set this to ["all"] to poll all sites, no matter their names.
+  Add more sites by adding additional lines:
+  <sites>site1</sites>
+  <sites>site2</sites>
+  -->
+  <sites>default</sites>
 
-<!--
-If the controller has more than one site, specify which sites to poll here.
-If only one site, "default" is likely the correct name.
-Set this to ["all"] to poll all sites, no matter their names.
-Add more sites by adding additional lines:
-<sites>site1</sites>
-<sites>site2</sites>
--->
-<sites>default</sites>
+  <!--
+  The Unifi Controller only updates traffic stats about every 30 seconds.
+  Setting this to something lower may lead to "zeros" in your data. You've been warned.
+  -->
+  <interval>30s</interval>
 
-<!--
-The Unifi Controller only updates traffic stats about every 30 seconds.
-Setting this to something lower may lead to "zeros" in your data. You've been warned.
--->
-<interval>30s</interval>
+  <!-- Turns on line numbers, microsecond logging, and a per-device log. -->
+  <debug>false</debug>
 
-<!-- Turns on line numbers, microsecond logging, and a per-device log. -->
-<debug>false</debug>
+  <!--
+  Turns off per-device log and per-interval log. Logs only errors.
+  Recommend using debug with this setting for better error logging.
+  -->
+  <quiet>false</quiet>
 
-<!--
-Turns off per-device log and per-interval log. Logs only errors.
-Recommend using debug with this setting for better error logging.
--->
-<quiet>false</quiet>
+  <!--
+  # If the poller experiences an error from the Unifi Controller or from InfluxDB
+  # it will exit. If you do not want it to exit, change max_errors to -1. You can
+  # adjust the config to tolerate more errors by setting this to a higher value.
+  # Recommend setting this between 0 and 5. See man page for more explanation.
+  -->
+  <max_errors>0</max_errors>
 
-<!--
-# If the poller experiences an error from the Unifi Controller or from InfluxDB
-# it will exit. If you do not want it to exit, change max_errors to -1. You can
-# adjust the config to tolerate more errors by setting this to a higher value.
-# Recommend setting this between 0 and 5. See man page for more explanation.
--->
-<max_errors>0</max_errors>
-
-<!-- InfluxDB does not require auth by default, so the user/password are probably unimportant. -->
-<influx_db>unifi</influx_db>
-<influx_pass>unifi</influx_pass>
-<influx_url>http://127.0.0.1:8086</influx_url>
-<influx_user>unifi</influx_user>
+  <!-- InfluxDB does not require auth by default, so the user/password are probably unimportant. -->
+  <influx_db>unifi</influx_db>
+  <influx_pass>unifi</influx_pass>
+  <influx_url>http://127.0.0.1:8086</influx_url>
+  <influx_user>unifi</influx_user>
 
 
-<!-- Make a read-only user in the Unifi Admin Settings. -->
-<unifi_user>influxdb</unifi_user>
-<unifi_pass></unifi_pass>
-<unifi_url>https://127.0.0.1:8443</unifi_url>
-<!--
-If your Unifi controller has a valid SSL certificate, you can enable
-this option to validate it. Otherwise, any SSL certificate is valid.
--->
-<verify_ssl>false</verify_ssl>
+  <!-- Make a read-only user in the Unifi Admin Settings. -->
+  <unifi_user>influxdb</unifi_user>
+  <unifi_pass></unifi_pass>
+  <unifi_url>https://127.0.0.1:8443</unifi_url>
+  <!--
+  If your Unifi controller has a valid SSL certificate, you can enable
+  this option to validate it. Otherwise, any SSL certificate is valid.
+  -->
+  <verify_ssl>false</verify_ssl>
+
+</unifi-poller>

--- a/examples/up.yaml.example
+++ b/examples/up.yaml.example
@@ -1,42 +1,42 @@
-# unifi-poller primary configuration file. TOML FORMAT #
-# commented lines are defaults, uncomment to change.   #
+# unifi-poller primary configuration file. YAML FORMAT #
+# provided values are defaults                         #
 ########################################################
-
+---
 # If the controller has more than one site, specify which sites to poll here.
 # If only one site, "default" is likely the correct name.
-# Set this to ["all"] to poll all sites, no matter their names.
-#sites = ["default"]
+# Change default to all to poll all sites, no matter their names.
+sites:
+  - default
 
 # The Unifi Controller only updates traffic stats about every 30 seconds.
 # Setting this to something lower may lead to "zeros" in your data. You've been warned.
-#interval = "30s"
+interval: "30s"
 
 # Turns on line numbers, microsecond logging, and a per-device log.
-#debug = false
+debug: false
 
 # Turns off per-device log and per-interval log. Logs only errors.
 # Recommend using debug with this setting for better error logging.
-#quiet = false
+quiet: false
 
 # If the poller experiences an error from the Unifi Controller or from InfluxDB
 # it will exit. If you do not want it to exit, change max_errors to -1. You can
 # adjust the config to tolerate more errors by setting this to a higher value.
 # Recommend setting this between 0 and 5. See man page for more explanation.
-#max_errors = 0
+max_errors: 0
 
 # InfluxDB does not require auth by default, so the user/password are probably unimportant.
-#influx_url = "http://127.0.0.1:8086"
-#influx_user = "unifi"
-#influx_pass = "unifi"
+influx_url: "http://127.0.0.1:8086"
+influx_user: "unifi"
+influx_pass: "unifi"
 # Be sure to create this database.
-#influx_db = "unifi"
+influx_db: "unifi"
 
 # Make a read-only user in the Unifi Admin Settings.
-#unifi_user = "influxdb"
-# You may also set env variable UNIFI_PASSWORD instead of putting this in the config.
-unifi_pass = "4BB9345C-2341-48D7-99F5-E01B583FF77F"
-#unifi_url = "https://127.0.0.1:8443"
+unifi_user: "influxdb"
+unifi_pass: ""
+unifi_url: "https://127.0.0.1:8443"
 
 # If your Unifi controller has a valid SSL certificate, you can enable
 # this option to validate it. Otherwise, any SSL certificate is valid.
-#verify_ssl = false
+verify_ssl: false

--- a/pkg/unifi-poller/config.go
+++ b/pkg/unifi-poller/config.go
@@ -1,7 +1,6 @@
 package unifipoller
 
 import (
-	"strings"
 	"time"
 
 	"github.com/golift/unifi"
@@ -67,14 +66,10 @@ type Config struct {
 }
 
 // Dur is used to UnmarshalTOML into a time.Duration value.
-type Dur struct{ value time.Duration }
+type Dur struct{ time.Duration }
 
-// UnmarshalTOML parses a duration type from a config file.
-func (v *Dur) UnmarshalTOML(data []byte) error {
-	unquoted := strings.Trim(string(data), `"`)
-	dur, err := time.ParseDuration(unquoted)
-	if err == nil {
-		v.value = dur
-	}
-	return err
+// UnmarshalText parses a duration type from a config file.
+func (d *Dur) UnmarshalText(data []byte) (err error) {
+	d.Duration, err = time.ParseDuration(string(data))
+	return
 }

--- a/pkg/unifi-poller/poller.go
+++ b/pkg/unifi-poller/poller.go
@@ -44,29 +44,22 @@ func (u *UnifiPoller) GetConfig() (err error) {
 		UnifiBase:  defaultUnifURL,
 		Interval:   Dur{defaultInterval},
 		Sites:      []string{"default"},
+		Quiet:      u.DumpJSON != "",
 	}
+	u.Logf("Loading Configuration File: %s", u.ConfigFile)
 	var buf []byte
 	switch buf, err = ioutil.ReadFile(u.ConfigFile); {
 	case err != nil:
 		return err
 	case strings.HasSuffix(u.ConfigFile, ".json"):
-		err = json.Unmarshal(buf, u.Config)
+		return json.Unmarshal(buf, u.Config)
 	case strings.HasSuffix(u.ConfigFile, ".xml"):
-		err = xml.Unmarshal(buf, u.Config)
+		return xml.Unmarshal(buf, u.Config)
 	case strings.HasSuffix(u.ConfigFile, ".yaml"):
-		err = yaml.Unmarshal(buf, u.Config)
+		return yaml.Unmarshal(buf, u.Config)
 	default:
-		err = toml.Unmarshal(buf, u.Config)
+		return toml.Unmarshal(buf, u.Config)
 	}
-	if err != nil {
-		return err
-	}
-
-	if u.DumpJSON != "" {
-		u.Quiet = true
-	}
-	u.Logf("Loaded Configuration: %s", u.ConfigFile)
-	return nil
 }
 
 // Run invokes all the application logic and routines.
@@ -74,7 +67,7 @@ func (u *UnifiPoller) Run() (err error) {
 	if u.DumpJSON != "" {
 		return u.DumpJSONPayload()
 	}
-	if log.SetFlags(0); u.Debug {
+	if u.Debug {
 		log.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
 		u.LogDebugf("Debug Logging Enabled")
 	}

--- a/pkg/unifi-poller/poller.go
+++ b/pkg/unifi-poller/poller.go
@@ -49,14 +49,14 @@ func (u *UnifiPoller) GetConfig() (err error) {
 	switch buf, err = ioutil.ReadFile(u.ConfigFile); {
 	case err != nil:
 		return err
-	default:
-		err = toml.Unmarshal(buf, u.Config)
 	case strings.HasSuffix(u.ConfigFile, ".json"):
 		err = json.Unmarshal(buf, u.Config)
 	case strings.HasSuffix(u.ConfigFile, ".xml"):
 		err = xml.Unmarshal(buf, u.Config)
 	case strings.HasSuffix(u.ConfigFile, ".yaml"):
 		err = yaml.Unmarshal(buf, u.Config)
+	default:
+		err = toml.Unmarshal(buf, u.Config)
 	}
 	if err != nil {
 		return err

--- a/pkg/unifi-poller/unifi.go
+++ b/pkg/unifi-poller/unifi.go
@@ -22,6 +22,7 @@ func (u *UnifiPoller) CheckSites() error {
 	}
 	u.Logf("Found %d site(s) on controller: %v", len(msg), strings.Join(msg, ", "))
 	if StringInSlice("all", u.Sites) {
+		u.Sites = []string{"all"}
 		return nil
 	}
 FIRST:

--- a/pkg/unifi-poller/unifi.go
+++ b/pkg/unifi-poller/unifi.go
@@ -38,8 +38,8 @@ FIRST:
 
 // PollController runs forever, polling unifi, and pushing to influx.
 func (u *UnifiPoller) PollController() error {
-	log.Println("[INFO] Everything checks out! Poller started, interval:", u.Interval.value)
-	ticker := time.NewTicker(u.Interval.value)
+	log.Println("[INFO] Everything checks out! Poller started, interval:", u.Interval.Round(time.Second))
+	ticker := time.NewTicker(u.Interval.Round(time.Second))
 	var err error
 	for range ticker.C {
 		m := &Metrics{}


### PR DESCRIPTION
This contribution adds the ability to load a config file from three new file formats. This provides flexibility in your deploy environment. We've also replaced the old TOML library with a newer, more maintained variant.