### PR TITLE
Fix config files. Do not overwrite them.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ $(BINARY)-$(RPMVERSION)-$(ITERATION).x86_64.rpm: check_fpm package_build_linux
 		--url $(URL) \
 		--maintainer "$(MAINT)" \
 		--description "$(DESC)" \
+		--config-files "/etc/$(BINARY)/" \
 		--chdir package_build_linux
 
 deb: clean $(BINARY)_$(VERSION)-$(ITERATION)_amd64.deb
@@ -110,6 +111,7 @@ $(BINARY)_$(VERSION)-$(ITERATION)_amd64.deb: check_fpm package_build_linux
 		--url $(URL) \
 		--maintainer "$(MAINT)" \
 		--description "$(DESC)" \
+		--config-files "/etc/$(BINARY)/" \
 		--chdir package_build_linux
 
 docker:


### PR DESCRIPTION
This contribution attempts to prevent the packages (rpm specifically) from overwriting the config file on upgrade. After this change:
```
[david@localhost ~]$ sudo rpm -Uvh unifi-poller-1.3.3-261.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:unifi-poller-1.3.3-261           warning: /etc/unifi-poller/up.conf created as /etc/unifi-poller/up.conf.rpmnew
Cleaning up / removing...
   2:unifi-poller-1.3.3-184           ################################# [100%]
[david@localhost ~]$
```

Tested on CentOS 7 in a virtual box. Closes #58.