### PR TITLE
Add IDS / IPS collection support.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,12 +10,12 @@
   version = "v0.3.1"
 
 [[projects]]
-  digest = "1:fc6a3f6bb5e5dbb5d36d04f8233896a985ffb5751bfc8c79c571ef2c72c324c7"
+  digest = "1:5dcb91bc89c052e58690416fafaf919def6e8e9ba018e143ffcfb10be961ba21"
   name = "github.com/golift/unifi"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a18b63b9c306f0cf744c7878bae7f9c42a8995a9"
-  version = "v3.1.1"
+  revision = "ecadb45c55ef371f3931333238ac9d1c827c684f"
+  version = "v3.2.0"
 
 [[projects]]
   branch = "master"

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -138,6 +138,12 @@ is provided so the application can be easily adapted to any environment.
         Password used to authenticate with UniFi controller. This can also be
         set in an environment variable instead of a configuration file.
 
+    collect_ids    default: false
+        Setting this parameter to true will enable collection of Intrusion
+        Detection System data. IDS and IPS are the same data set. This is off
+        by default because most controllers do not have this enabled. It also
+        creates a lot of new metrics from controllers with a lot of IDS entries.
+
     verify_ssl     default: false
         If your UniFi controller has a valid SSL certificate, you can enable
         this option to validate it. Otherwise, any SSL certificate is valid.

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -50,6 +50,10 @@
 unifi_pass = "4BB9345C-2341-48D7-99F5-E01B583FF77F"
 #unifi_url = "https://127.0.0.1:8443"
 
+# Enable collection of Intrusion Detection System Data.
+# Only useful if IDS or IPS are enabled on one of the sites.
+#collect_ids = false
+
 # If your UniFi controller has a valid SSL certificate, you can enable
 # this option to validate it. Otherwise, any SSL certificate is valid.
 # If you don't know if you have a valid SSL cert, then you don't have one.

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -12,5 +12,6 @@
  "unifi_user": "influxdb",
  "unifi_pass": "",
  "unifi_url": "https://127.0.0.1:8443",
+ "collect_ids": false,
  "verify_ssl": false
 }

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -72,6 +72,11 @@
   <unifi_pass></unifi_pass>
   <unifi_url>https://127.0.0.1:8443</unifi_url>
   <!--
+  # Enable collection of Intrusion Detection System Data.
+  # Only useful if IDS or IPS are enabled on one of the sites.
+  -->
+  <collect_ids>false</collect_ids>
+  <!--
   # If your UniFi controller has a valid SSL certificate, you can enable
   # this option to validate it. Otherwise, any SSL certificate is valid.
   -->

--- a/examples/up.yaml.example
+++ b/examples/up.yaml.example
@@ -50,6 +50,10 @@ unifi_user: "influxdb"
 unifi_pass: ""
 unifi_url: "https://127.0.0.1:8443"
 
+# Enable collection of Intrusion Detection System Data.
+# Only useful if IDS or IPS are enabled on one of the sites.
+collect_ids: false
+
 # If your UniFi controller has a valid SSL certificate, you can enable
 # this option to validate it. Otherwise, any SSL certificate is valid.
 verify_ssl: false

--- a/unifipoller/config.go
+++ b/unifipoller/config.go
@@ -43,6 +43,7 @@ type UnifiPoller struct {
 // Metrics contains all the data from the controller and an influx endpoint to send it to.
 type Metrics struct {
 	unifi.Sites
+	unifi.IDSList
 	unifi.Clients
 	*unifi.Devices
 	influx.BatchPoints
@@ -56,6 +57,7 @@ type Config struct {
 	Debug      bool     `json:"debug" toml:"debug" xml:"debug" yaml:"debug"`
 	Quiet      bool     `json:"quiet,_omitempty" toml:"quiet,_omitempty" xml:"quiet" yaml:"quiet"`
 	VerifySSL  bool     `json:"verify_ssl" toml:"verify_ssl" xml:"verify_ssl" yaml:"verify_ssl"`
+	CollectIDS bool     `json:"collect_ids" toml:"collect_ids" xml:"collect_ids" yaml:"collect_ids"`
 	Mode       string   `json:"mode" toml:"mode" xml:"mode" yaml:"mode"`
 	InfluxURL  string   `json:"influx_url,_omitempty" toml:"influx_url,_omitempty" xml:"influx_url" yaml:"influx_url"`
 	InfluxUser string   `json:"influx_user,_omitempty" toml:"influx_user,_omitempty" xml:"influx_user" yaml:"influx_user"`


### PR DESCRIPTION
This brings a conclusion to #68. Adds collection of intrusion detection system data. There are no graphs or dashboards available because this is not a commonly used feature, and honestly I don't know how to make it look any better or different than what's in the controller interface now.

The [data itself](https://github.com/golift/unifi/blob/ecadb45c55ef371f3931333238ac9d1c827c684f/examples/ids.json) has no real bits that can be graphed. You can pretty much just count it (singlestat panel) and create a table from each "intrusion event." This is pretty much exactly how it's displayed in the UniFi controller, and meh, it's whatever. I think it could be better. I chose not to [import all the data from the controller](https://github.com/golift/unifi/blob/ecadb45c55ef371f3931333238ac9d1c827c684f/ids.go#L149-L176) and I omitted IP addresses because of their high cardinality. I'm up for discussion on my implementation. We can and should definitely amend it as we figure out what works for this data set. Please open an Issue if you think it can be better.