### PR TITLE
Add reauth feature, remove errors library.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,14 +22,6 @@
   revision = "fc22c7df067eefd070157f157893fbce961d6359"
 
 [[projects]]
-  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
-  version = "v0.8.1"
-
-[[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
@@ -59,7 +51,6 @@
   input-imports = [
     "github.com/BurntSushi/toml",
     "github.com/influxdata/influxdb1-client/v2",
-    "github.com/pkg/errors",
     "github.com/spf13/pflag",
     "golift.io/unifi",
     "gopkg.in/yaml.v2",

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -65,7 +65,7 @@ is provided so the application can be easily adapted to any environment.
 
 `Config File Parameters`
 
-    sites          default: ["all"]
+    sites           default: ["all"]
         This list of strings should represent the names of sites on the UniFi
         controller that will be polled for data. Pass `all` in the list to
         poll all sites. On startup, the application prints out all site names
@@ -73,20 +73,20 @@ is provided so the application can be easily adapted to any environment.
         next to them. The cryptic names go into the config file `sites` list.
         The controller's first site is not cryptic and is named `default`.
 
-    interval       default: 30s
+    interval        default: 30s
         How often to poll the controller for updated client and device data.
         The UniFi Controller only updates traffic stats about every 30 seconds.
 
-    debug          default: false
+    debug           default: false
         This turns on time stamps and line numbers in logs, outputs a few extra
         lines of information while processing.
 
-    quiet          default: false  
+    quiet           default: false
         Setting this to true will turn off per-device and per-interval logs. Only
         errors will be logged. Using this with debug=true adds line numbers to
         any error logs.
 
-    mode           default: "influx"
+    mode            default: "influx"
         * Value: influx
         This default mode runs this application as a daemon. It will poll
         the controller at the configured interval. Providing an invalid value
@@ -101,7 +101,7 @@ is provided so the application can be easily adapted to any environment.
         This mode can also be combined with a "test database" in InfluxDB to
         give yourself a "test config file" you may run ad-hoc to test changes.
 
-    max_errors     default: 0
+    max_errors      default: 0
         If you restart the UniFI controller, the poller will lose access until
         it is restarted. Specifying a number greater than -1 for max_errors will
         cause the poller to exit when it reaches the error count specified.
@@ -113,16 +113,16 @@ is provided so the application can be easily adapted to any environment.
         docker or launchd. The default setting of 0 will cause an exit after
         just 1 error. Recommended values are 0-5.
 
-    influx_url     default: http://127.0.0.1:8086
+    influx_url      default: http://127.0.0.1:8086
         This is the URL where the Influx web server is available.
 
-    influx_user    default: unifi
+    influx_user     default: unifi
         Username used to authenticate with InfluxDB.
 
-    influx_pass    default: unifi
+    influx_pass     default: unifi
         Password used to authenticate with InfluxDB.
 
-    influx_db      default: unifi
+    influx_db       default: unifi
         Custom database created in InfluxDB to use with this application.
         On first setup, log into InfluxDB and create access:
         $ influx -host localhost -port 8086
@@ -130,24 +130,30 @@ is provided so the application can be easily adapted to any environment.
         CREATE USER unifi WITH PASSWORD 'unifi' WITH ALL PRIVILEGES
         GRANT ALL ON unifi TO unifi
 
-    unifi_url      default: https://127.0.0.1:8443
+    unifi_url       default: https://127.0.0.1:8443
         This is the URL where the UniFi Controller is available.
 
-    unifi_user     default: influxdb
+    unifi_user      default: influxdb
         Username used to authenticate with UniFi controller. This should be a
         special service account created on the control with read-only access.
 
-    unifi_user     no default   ENV: UNIFI_PASSWORD
+    unifi_user      no default   ENV: UNIFI_PASSWORD
         Password used to authenticate with UniFi controller. This can also be
         set in an environment variable instead of a configuration file.
 
-    collect_ids    default: false
+    collect_ids     default: false
         Setting this parameter to true will enable collection of Intrusion
         Detection System data. IDS and IPS are the same data set. This is off
         by default because most controllers do not have this enabled. It also
         creates a lot of new metrics from controllers with a lot of IDS entries.
 
-    verify_ssl     default: false
+    reauthenticate  default: false
+        Setting this parameter to true will make UniFi Poller send a new login
+        request on every interval. This generates a new cookie. Some controller
+        or reverse proxy configurations require this. Do not enable it unless
+        your configuration causes the poller to be logged out after some time.
+
+    verify_ssl      default: false
         If your UniFi controller has a valid SSL certificate, you can enable
         this option to validate it. Otherwise, any SSL certificate is valid.
 

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -54,7 +54,14 @@ unifi_pass = "4BB9345C-2341-48D7-99F5-E01B583FF77F"
 # Only useful if IDS or IPS are enabled on one of the sites.
 #collect_ids = false
 
-# If your UniFi controller has a valid SSL certificate, you can enable
-# this option to validate it. Otherwise, any SSL certificate is valid.
-# If you don't know if you have a valid SSL cert, then you don't have one.
+# Some controllers or reverse proxy configurations do not allow cookies to be
+# re-user on every request (every interval). This setting provides a workaround
+# That causes the poller to re-auth (login) to the controller on every interval.
+# Only enable this if you get login errors after 30 seconds. This will generate
+# a few more requests to your controller every interval.
+#reauthenticate = false
+
+# If your UniFi controller has a valid SSL certificate (like lets encrypt),
+# you can enable this option to validate it. Otherwise, any SSL certificate is
+# valid. If you don't know if you have a valid SSL cert, then you don't have one.
 #verify_ssl = false

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -5,20 +5,20 @@
 # If the controller has more than one site, specify which sites to poll here.
 # Set this to ["default"] to poll only the first site on the controller.
 # A setting of ["all"] will poll all sites; this works if you only have 1 site too.
-#sites = ["all"]
+sites = ["all"]
 
 # The UniFi Controller only updates traffic stats about every 30 seconds.
 # Setting this to something lower may lead to "zeros" in your data. You've been warned.
-#interval = "30s"
+interval = "30s"
 
 # Turns on line numbers, microsecond logging, and a per-device log.
 # The default is false, but I personally leave this on at home (four devices).
 # This may be noisy if you have a lot of devices. It adds one line per device.
-#debug = false
+debug = false
 
 # Turns off per-interval logs. Only startup and error logs will be emitted.
 # Recommend enabling debug with this setting for better error logging.
-#quiet = false
+quiet = false
 
 # Which mode to run this application in. The default mode is "influx". Providing
 # an invalid mode will also result in "influx". In this default mode the application
@@ -29,39 +29,39 @@
 # Lambda mode makes the application exit after collecting and reporting metrics
 # to InfluxDB one time. This mode requires an external process like an AWS Lambda
 # or a simple crontab to keep the timings accurate on UniFi Poller run intervals.
-#mode = "influx"
+mode = "influx"
 
 # If the poller experiences an error from the UniFi controller or from InfluxDB
 # it will exit. If you do not want it to exit, change max_errors to -1. You can
 # adjust the config to tolerate more errors by setting this to a higher value.
 # Recommend setting this between 0 and 5. See man page for more explanation.
-#max_errors = 0
+max_errors = 0
 
 # InfluxDB does not require auth by default, so the user/password are probably unimportant.
-#influx_url = "http://127.0.0.1:8086"
-#influx_user = "unifi"
-#influx_pass = "unifi"
+influx_url = "http://127.0.0.1:8086"
+influx_user = "unifi"
+influx_pass = "unifi"
 # Be sure to create this database.
-#influx_db = "unifi"
+influx_db = "unifi"
 
 # Make a read-only user in the UniFi Admin Settings.
-#unifi_user = "influxdb"
+unifi_user = "influxdb"
 # You may also set env variable UNIFI_PASSWORD instead of putting this in the config.
 unifi_pass = "4BB9345C-2341-48D7-99F5-E01B583FF77F"
-#unifi_url = "https://127.0.0.1:8443"
+unifi_url = "https://127.0.0.1:8443"
 
 # Enable collection of Intrusion Detection System Data.
 # Only useful if IDS or IPS are enabled on one of the sites.
-#collect_ids = false
+collect_ids = false
 
 # Some controllers or reverse proxy configurations do not allow cookies to be
 # re-user on every request (every interval). This setting provides a workaround
 # That causes the poller to re-auth (login) to the controller on every interval.
 # Only enable this if you get login errors after 30 seconds. This will generate
 # a few more requests to your controller every interval.
-#reauthenticate = false
+reauthenticate = false
 
 # If your UniFi controller has a valid SSL certificate (like lets encrypt),
 # you can enable this option to validate it. Otherwise, any SSL certificate is
 # valid. If you don't know if you have a valid SSL cert, then you don't have one.
-#verify_ssl = false
+verify_ssl = false

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -13,5 +13,6 @@
  "unifi_pass": "",
  "unifi_url": "https://127.0.0.1:8443",
  "collect_ids": false,
+ "reauthenticate": false,
  "verify_ssl": false
 }

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -77,6 +77,14 @@
   -->
   <collect_ids>false</collect_ids>
   <!--
+  # Some controllers or reverse proxy configurations do not allow cookies to be
+  # re-user on every request (every interval). This setting provides a workaround
+  # That causes the poller to re-auth (login) to the controller on every interval.
+  # Only enable this if you get login errors after 30 seconds. This will generate
+  # a few more requests to your controller every interval.
+  -->
+  <reauthenticate>false</reauthenticate>
+  <!--
   # If your UniFi controller has a valid SSL certificate, you can enable
   # this option to validate it. Otherwise, any SSL certificate is valid.
   -->

--- a/examples/up.yaml.example
+++ b/examples/up.yaml.example
@@ -54,6 +54,13 @@ unifi_url: "https://127.0.0.1:8443"
 # Only useful if IDS or IPS are enabled on one of the sites.
 collect_ids: false
 
+# Some controllers or reverse proxy configurations do not allow cookies to be
+# re-user on every request (every interval). This setting provides a workaround
+# That causes the poller to re-auth (login) to the controller on every interval.
+# Only enable this if you get login errors after 30 seconds. This will generate
+# a few more requests to your controller every interval.
+reauthenticate: false
+
 # If your UniFi controller has a valid SSL certificate, you can enable
 # this option to validate it. Otherwise, any SSL certificate is valid.
 verify_ssl: false

--- a/unifipoller/config.go
+++ b/unifipoller/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	Quiet      bool     `json:"quiet,_omitempty" toml:"quiet,_omitempty" xml:"quiet" yaml:"quiet"`
 	VerifySSL  bool     `json:"verify_ssl" toml:"verify_ssl" xml:"verify_ssl" yaml:"verify_ssl"`
 	CollectIDS bool     `json:"collect_ids" toml:"collect_ids" xml:"collect_ids" yaml:"collect_ids"`
+	ReAuth     bool     `json:"reauthenticate" toml:"reauthenticate" xml:"reauthenticate" yaml:"reauthenticate"`
 	Mode       string   `json:"mode" toml:"mode" xml:"mode" yaml:"mode"`
 	InfluxURL  string   `json:"influx_url,_omitempty" toml:"influx_url,_omitempty" xml:"influx_url" yaml:"influx_url"`
 	InfluxUser string   `json:"influx_user,_omitempty" toml:"influx_user,_omitempty" xml:"influx_user" yaml:"influx_user"`

--- a/unifipoller/dumper.go
+++ b/unifipoller/dumper.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golift.io/unifi"
 )
 
@@ -35,7 +34,7 @@ func (u *UnifiPoller) DumpJSONPayload() (err error) {
 		_, _ = fmt.Fprintf(os.Stderr, "[INFO] Dumping Path '%s':\n", apiPath)
 		return u.PrintRawAPIJSON(apiPath)
 	default:
-		return errors.New("must provide filter: devices, clients, other")
+		return fmt.Errorf("must provide filter: devices, clients, other")
 	}
 }
 


### PR DESCRIPTION
This contribution adds a new feature to re-authenticate to the controller every interval.This is an attempt to fix #89. Setting `reauthentiate` to `true` in the config will make the poller get a new auth cookie for every poll interval. 

I also refactored a little bit of code and removed the `errors` library.