### PR TITLE
Remove max errors parameter

### DIFF
--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -101,18 +101,6 @@ is provided so the application can be easily adapted to any environment.
         This mode can also be combined with a "test database" in InfluxDB to
         give yourself a "test config file" you may run ad-hoc to test changes.
 
-    max_errors             default: 0
-        If you restart the UniFI controller, the poller will lose access until
-        it is restarted. Specifying a number greater than -1 for max_errors will
-        cause the poller to exit when it reaches the error count specified.
-        This problematic condition can be triggered by InfluxDB having issues
-        too. Generally only 1 error per interval is created, but if more than one
-        backend is having issues > 1 error could be generated per interval. Once
-        the poller exits, it is expected that something will restart it
-        automatically so it gets back in line; something is usually systemd,
-        docker or launchd. The default setting of 0 will cause an exit after
-        just 1 error. Recommended values are 0-5.
-
     influx_url             default: http://127.0.0.1:8086
         This is the URL where the Influx web server is available.
 

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -31,12 +31,6 @@ quiet = false
 # or a simple crontab to keep the timings accurate on UniFi Poller run intervals.
 mode = "influx"
 
-# If the poller experiences an error from the UniFi controller or from InfluxDB
-# it will exit. If you do not want it to exit, change max_errors to -1. You can
-# adjust the config to tolerate more errors by setting this to a higher value.
-# Recommend setting this between 0 and 5. See man page for more explanation.
-max_errors = 0
-
 # InfluxDB does not require auth by default, so the user/password are probably unimportant.
 influx_url = "http://127.0.0.1:8086"
 influx_user = "unifi"

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -4,7 +4,6 @@
  "debug": false,
  "quiet": false,
  "mode": "influx",
- "max_errors": 0,
  "influx_url": "http://127.0.0.1:8086",
  "influx_user": "unifi",
  "influx_pass": "unifi",

--- a/examples/up.xml.example
+++ b/examples/up.xml.example
@@ -49,14 +49,6 @@
   <mode>influx</mode>
 
   <!--
-  # If the poller experiences an error from the UniFi controller or from InfluxDB
-  # it will exit. If you do not want it to exit, change max_errors to -1. You can
-  # adjust the config to tolerate more errors by setting this to a higher value.
-  # Recommend setting this between 0 and 5. See man page for more explanation.
-  -->
-  <max_errors>0</max_errors>
-
-  <!--
   # InfluxDB does not require auth by default, so the user/password are probably unimportant.
   -->
   <influx_db>unifi</influx_db>

--- a/examples/up.yaml.example
+++ b/examples/up.yaml.example
@@ -32,12 +32,6 @@ quiet: false
 # or a simple crontab to keep the timings accurate on UniFi Poller run intervals.
 mode: "influx"
 
-# If the poller experiences an error from the UniFi controller or from InfluxDB
-# it will exit. If you do not want it to exit, change max_errors to -1. You can
-# adjust the config to tolerate more errors by setting this to a higher value.
-# Recommend setting this between 0 and 5. See man page for more explanation.
-max_errors: 0
-
 # InfluxDB does not require auth by default, so the user/password are probably unimportant.
 influx_url: "http://127.0.0.1:8086"
 influx_user: "unifi"

--- a/unifipoller/config.go
+++ b/unifipoller/config.go
@@ -67,24 +67,24 @@ type Metrics struct {
 
 // Config represents the data needed to poll a controller and report to influxdb.
 // This is all of the data stored in the config file.
-// Any with explicit defaults have _omitempty on json and toml tags.
+// Any with explicit defaults have omitempty on json and toml tags.
 type Config struct {
-	Interval   Duration `json:"interval,_omitempty" toml:"interval,_omitempty" xml:"interval" yaml:"interval" env:"POLLING_INTERVAL"`
+	Interval   Duration `json:"interval,omitempty" toml:"interval,omitempty" xml:"interval" yaml:"interval" env:"POLLING_INTERVAL"`
 	Debug      bool     `json:"debug" toml:"debug" xml:"debug" yaml:"debug" env:"DEBUG_MODE"`
-	Quiet      bool     `json:"quiet,_omitempty" toml:"quiet,_omitempty" xml:"quiet" yaml:"quiet" env:"QUIET_MODE"`
+	Quiet      bool     `json:"quiet,omitempty" toml:"quiet,omitempty" xml:"quiet" yaml:"quiet" env:"QUIET_MODE"`
 	VerifySSL  bool     `json:"verify_ssl" toml:"verify_ssl" xml:"verify_ssl" yaml:"verify_ssl" env:"VERIFY_SSL"`
 	CollectIDS bool     `json:"collect_ids" toml:"collect_ids" xml:"collect_ids" yaml:"collect_ids" env:"COLLECT_IDS"`
 	ReAuth     bool     `json:"reauthenticate" toml:"reauthenticate" xml:"reauthenticate" yaml:"reauthenticate" env:"REAUTHENTICATE"`
 	InfxBadSSL bool     `json:"influx_insecure_ssl" toml:"influx_insecure_ssl" xml:"influx_insecure_ssl" yaml:"influx_insecure_ssl" env:"INFLUX_INSECURE_SSL"`
 	Mode       string   `json:"mode" toml:"mode" xml:"mode" yaml:"mode" env:"POLLING_MODE"`
-	InfluxURL  string   `json:"influx_url,_omitempty" toml:"influx_url,_omitempty" xml:"influx_url" yaml:"influx_url" env:"INFLUX_URL"`
-	InfluxUser string   `json:"influx_user,_omitempty" toml:"influx_user,_omitempty" xml:"influx_user" yaml:"influx_user" env:"INFLUX_USER"`
-	InfluxPass string   `json:"influx_pass,_omitempty" toml:"influx_pass,_omitempty" xml:"influx_pass" yaml:"influx_pass" env:"INFLUX_PASS"`
-	InfluxDB   string   `json:"influx_db,_omitempty" toml:"influx_db,_omitempty" xml:"influx_db" yaml:"influx_db" env:"INFLUX_DB"`
-	UnifiUser  string   `json:"unifi_user,_omitempty" toml:"unifi_user,_omitempty" xml:"unifi_user" yaml:"unifi_user" env:"UNIFI_USER"`
-	UnifiPass  string   `json:"unifi_pass,_omitempty" toml:"unifi_pass,_omitempty" xml:"unifi_pass" yaml:"unifi_pass" env:"UNIFI_PASS"`
-	UnifiBase  string   `json:"unifi_url,_omitempty" toml:"unifi_url,_omitempty" xml:"unifi_url" yaml:"unifi_url" env:"UNIFI_URL"`
-	Sites      []string `json:"sites,_omitempty" toml:"sites,_omitempty" xml:"sites" yaml:"sites" env:"POLL_SITES"`
+	InfluxURL  string   `json:"influx_url,omitempty" toml:"influx_url,omitempty" xml:"influx_url" yaml:"influx_url" env:"INFLUX_URL"`
+	InfluxUser string   `json:"influx_user,omitempty" toml:"influx_user,omitempty" xml:"influx_user" yaml:"influx_user" env:"INFLUX_USER"`
+	InfluxPass string   `json:"influx_pass,omitempty" toml:"influx_pass,omitempty" xml:"influx_pass" yaml:"influx_pass" env:"INFLUX_PASS"`
+	InfluxDB   string   `json:"influx_db,omitempty" toml:"influx_db,omitempty" xml:"influx_db" yaml:"influx_db" env:"INFLUX_DB"`
+	UnifiUser  string   `json:"unifi_user,omitempty" toml:"unifi_user,omitempty" xml:"unifi_user" yaml:"unifi_user" env:"UNIFI_USER"`
+	UnifiPass  string   `json:"unifi_pass,omitempty" toml:"unifi_pass,omitempty" xml:"unifi_pass" yaml:"unifi_pass" env:"UNIFI_PASS"`
+	UnifiBase  string   `json:"unifi_url,omitempty" toml:"unifi_url,omitempty" xml:"unifi_url" yaml:"unifi_url" env:"UNIFI_URL"`
+	Sites      []string `json:"sites,omitempty" toml:"sites,omitempty" xml:"sites" yaml:"sites" env:"POLL_SITES"`
 }
 
 // Duration is used to UnmarshalTOML into a time.Duration value.

--- a/unifipoller/config.go
+++ b/unifipoller/config.go
@@ -69,7 +69,6 @@ type Metrics struct {
 // This is all of the data stored in the config file.
 // Any with explicit defaults have _omitempty on json and toml tags.
 type Config struct {
-	MaxErrors  int      `json:"max_errors" toml:"max_errors" xml:"max_errors" yaml:"max_errors" env:"MAX_ERRORS"`
 	Interval   Duration `json:"interval,_omitempty" toml:"interval,_omitempty" xml:"interval" yaml:"interval" env:"POLLING_INTERVAL"`
 	Debug      bool     `json:"debug" toml:"debug" xml:"debug" yaml:"debug" env:"DEBUG_MODE"`
 	Quiet      bool     `json:"quiet,_omitempty" toml:"quiet,_omitempty" xml:"quiet" yaml:"quiet" env:"QUIET_MODE"`

--- a/unifipoller/helpers.go
+++ b/unifipoller/helpers.go
@@ -11,7 +11,7 @@ import (
 func (u *UnifiPoller) LogError(err error, prefix string) {
 	if err != nil {
 		u.errorCount++
-		_ = log.Output(2, fmt.Sprintf("[ERROR] (%v/%v) %v: %v", u.errorCount, u.Config.MaxErrors, prefix, err))
+		_ = log.Output(2, fmt.Sprintf("[ERROR] %v: %v", prefix, err))
 	}
 }
 

--- a/unifipoller/unifi.go
+++ b/unifipoller/unifi.go
@@ -62,9 +62,8 @@ func (u *UnifiPoller) PollController() error {
 			// Only run this if the authentication procedure didn't return error.
 			_ = u.CollectAndReport()
 		}
-		if u.Config.MaxErrors >= 0 && u.errorCount > u.Config.MaxErrors {
-			return fmt.Errorf("reached maximum error count, stopping poller (%d > %d)",
-				u.errorCount, u.Config.MaxErrors)
+		if u.errorCount > 0 {
+			return fmt.Errorf("controller or influxdb errors, stopping poller")
 		}
 	}
 	return nil


### PR DESCRIPTION
I added max errors as a way to control how the application exits when it encounters an error. This didn't really work the way I wanted because it's a static setting being checked against a counter than never resets. This behavior is confusing and leads to the belief that increasing the max errors will solve some problems or allow the poller to continue working after a controller restart. That is just not the case. I believe removing this parameter is best.

I could add more logic to make it work in a time window, but there is really not much value to controlling an error counter. It's either working or it's not. So far, exiting on error and allowing the launch controller to bring the poller back up has been working well for people. I've helped users get this working correctly on macOS, Linux and Docker; some of whom know more about these things than I do, so I'm convinced this approach works.

I've also helped enough new poller users troubleshoot their initial installation that I'm further convinced exiting during an error is the best default behavior.

I will keep the idea of re-authenticating automatically in mind, but it requires some code re-factor to differentiate InfluxDB errors from controller errors, and to further figure out how to handle InfluxDB failures.

This closes #123 by virtue of removing the confusing configuration parameter and making the default (and only possible) behavior explicit.