### PR TITLE
dpkg --force-confdef --force-confold --install

### DIFF
--- a/init/launchd/README.md
+++ b/init/launchd/README.md
@@ -1,0 +1,2 @@
+This file isn't used by the build or for any packages. The homebrew launchd is
+in the [homebrew](../homebrew) folder. This file is for reference only.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,7 +76,7 @@ fi
 
 INSTALLER="rpm -Uvh"
 if [ "$FILE" = "deb" ]; then
-  INSTALLER="dpkg -i"
+  INSTALLER="dpkg --force-confdef --force-confold --install"
 fi
 
 FILE=$(basename ${URL})


### PR DESCRIPTION
This resolves #111 by _not overwriting_ the config file when a package is upgraded on debian using the install.sh script.