### PR TITLE
Cleanup duplicate station metrics

### DIFF
--- a/pkg/promunifi/udm.go
+++ b/pkg/promunifi/udm.go
@@ -20,8 +20,6 @@ type unifiDevice struct {
 	TxBytesD      *prometheus.Desc // ap only
 	RxBytesD      *prometheus.Desc // ap only
 	NumSta        *prometheus.Desc
-	UserNumSta    *prometheus.Desc
-	GuestNumSta   *prometheus.Desc
 	NumDesktop    *prometheus.Desc // gw only
 	NumMobile     *prometheus.Desc // gw only
 	NumHandheld   *prometheus.Desc // gw only
@@ -50,9 +48,7 @@ func descDevice(ns string) *unifiDevice {
 		Bytes:         prometheus.NewDesc(ns+"transferred_bytes_total", "Bytes Transferred", labels, nil),
 		TxBytesD:      prometheus.NewDesc(ns+"d_tranmsit_bytes", "Transmit Bytes D???", labels, nil),
 		RxBytesD:      prometheus.NewDesc(ns+"d_receive_bytes", "Receive Bytes D???", labels, nil),
-		NumSta:        prometheus.NewDesc(ns+"stations", "Number of Stations", labels, nil),
-		UserNumSta:    prometheus.NewDesc(ns+"user_stations", "Number of User Stations", labels, nil),
-		GuestNumSta:   prometheus.NewDesc(ns+"guest_stations", "Number of Guest Stations", labels, nil),
+		NumSta:        prometheus.NewDesc(ns+"stations", "Number of Stations", append(labels, "station_type"), nil),
 		NumDesktop:    prometheus.NewDesc(ns+"desktops", "Number of Desktops", labels, nil),
 		NumMobile:     prometheus.NewDesc(ns+"mobile", "Number of Mobiles", labels, nil),
 		NumHandheld:   prometheus.NewDesc(ns+"handheld", "Number of Handhelds", labels, nil),
@@ -70,15 +66,16 @@ func descDevice(ns string) *unifiDevice {
 // UDM is a collection of stats from USG, USW and UAP. It has no unique stats.
 func (u *promUnifi) exportUDM(r report, d *unifi.UDM) {
 	labels := []string{d.IP, d.Version, d.Model, d.Serial, d.Type, d.Mac, d.SiteName, d.Name}
+	labelsGuest := append(labels, "guest")
+	labelsUser := append(labels, "user")
 	// Dream Machine System Data.
 	r.send([]*metric{
 		{u.Device.Uptime, prometheus.GaugeValue, d.Uptime, labels},
 		{u.Device.TotalTxBytes, prometheus.CounterValue, d.TxBytes, labels},
 		{u.Device.TotalRxBytes, prometheus.CounterValue, d.RxBytes, labels},
 		{u.Device.TotalBytes, prometheus.CounterValue, d.Bytes, labels},
-		{u.Device.NumSta, prometheus.GaugeValue, d.NumSta, labels},
-		{u.Device.UserNumSta, prometheus.GaugeValue, d.UserNumSta, labels},
-		{u.Device.GuestNumSta, prometheus.GaugeValue, d.GuestNumSta, labels},
+		{u.Device.NumSta, prometheus.GaugeValue, d.UserNumSta, labelsUser},
+		{u.Device.NumSta, prometheus.GaugeValue, d.GuestNumSta, labelsGuest},
 		{u.Device.NumDesktop, prometheus.GaugeValue, d.NumDesktop, labels},
 		{u.Device.NumMobile, prometheus.GaugeValue, d.NumMobile, labels},
 		{u.Device.NumHandheld, prometheus.GaugeValue, d.NumHandheld, labels},

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -72,15 +72,16 @@ func descUSG(ns string) *usg {
 
 func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
 	labels := []string{d.IP, d.Version, d.Model, d.Serial, d.Type, d.Mac, d.SiteName, d.Name}
+	labelsUser := append(labels, "user")
+	labelsGuest := append(labels, "guest")
 	// Gateway System Data.
 	r.send([]*metric{
 		{u.Device.Uptime, prometheus.GaugeValue, d.Uptime, labels},
 		{u.Device.TotalTxBytes, prometheus.CounterValue, d.TxBytes, labels},
 		{u.Device.TotalRxBytes, prometheus.CounterValue, d.RxBytes, labels},
 		{u.Device.TotalBytes, prometheus.CounterValue, d.Bytes, labels},
-		{u.Device.NumSta, prometheus.GaugeValue, d.NumSta, labels},
-		{u.Device.UserNumSta, prometheus.GaugeValue, d.UserNumSta, labels},
-		{u.Device.GuestNumSta, prometheus.GaugeValue, d.GuestNumSta, labels},
+		{u.Device.NumSta, prometheus.GaugeValue, d.UserNumSta, labelsUser},
+		{u.Device.NumSta, prometheus.GaugeValue, d.GuestNumSta, labelsGuest},
 		{u.Device.NumDesktop, prometheus.GaugeValue, d.NumDesktop, labels},
 		{u.Device.NumMobile, prometheus.GaugeValue, d.NumMobile, labels},
 		{u.Device.NumHandheld, prometheus.GaugeValue, d.NumHandheld, labels},

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -92,6 +92,8 @@ func descUSW(ns string) *usw {
 
 func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 	labels := []string{d.IP, d.Version, d.Model, d.Serial, d.Type, d.Mac, d.SiteName, d.Name}
+	labelsGuest := append(labels, "guest")
+	labelsUser := append(labels, "user")
 	if d.HasTemperature.Val {
 		r.send([]*metric{{u.Device.Temperature, prometheus.GaugeValue, d.GeneralTemperature, labels}})
 	}
@@ -106,9 +108,8 @@ func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 		{u.Device.TotalTxBytes, prometheus.CounterValue, d.TxBytes, labels},
 		{u.Device.TotalRxBytes, prometheus.CounterValue, d.RxBytes, labels},
 		{u.Device.TotalBytes, prometheus.CounterValue, d.Bytes, labels},
-		{u.Device.NumSta, prometheus.GaugeValue, d.NumSta, labels},
-		{u.Device.UserNumSta, prometheus.GaugeValue, d.UserNumSta, labels},
-		{u.Device.GuestNumSta, prometheus.GaugeValue, d.GuestNumSta, labels},
+		{u.Device.NumSta, prometheus.GaugeValue, d.UserNumSta, labelsUser},
+		{u.Device.NumSta, prometheus.GaugeValue, d.GuestNumSta, labelsGuest},
 		{u.Device.Loadavg1, prometheus.GaugeValue, d.SysStats.Loadavg1, labels},
 		{u.Device.Loadavg5, prometheus.GaugeValue, d.SysStats.Loadavg5, labels},
 		{u.Device.Loadavg15, prometheus.GaugeValue, d.SysStats.Loadavg15, labels},


### PR DESCRIPTION
Combine "user" and "guest" station metrics into a single labeled metric
to avoid duplicate storage of the same data.

Signed-off-by: Ben Kochie <superq@gmail.com>