### PR TITLE
Move excess device labels to info metric

### DIFF
--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -165,7 +165,7 @@ func descUAP(ns string) *uap {
 
 func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 	labels := []string{d.Type, d.SiteName, d.Name}
-	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
+	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac}
 	// Wireless System Data.
 	r.send([]*metric{
 		{u.Device.Info, prometheus.GaugeValue, 1.0, append(labels, infoLabels...)},

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -197,8 +197,8 @@ func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 
 func (u *promUnifi) exportUAPstats(r report, labels []string, ap *unifi.Ap) {
 	//	labelA := append([]string{"all"}, labels[2:]...)
-	labelU := append([]string{"user"}, labels[1:]...)
-	labelG := append([]string{"guest"}, labels[1:]...)
+	labelU := []string{"user", labels[1], labels[2]}
+	labelG := []string{"guest", labels[1], labels[2]}
 	r.send([]*metric{
 		/* // all
 		{u.UAP.ApWifiTxDropped, prometheus.CounterValue, ap.WifiTxDropped, labelA},
@@ -255,7 +255,7 @@ func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable)
 		if !v.Up.Val {
 			continue
 		}
-		labelV := append([]string{v.Name, v.Bssid, v.Radio, v.RadioName, v.Essid, v.Usage}, labels[1:]...)
+		labelV := []string{v.Name, v.Bssid, v.Radio, v.RadioName, v.Essid, v.Usage, labels[1], labels[2]}
 
 		r.send([]*metric{
 			{u.UAP.VAPCcq, prometheus.GaugeValue, float64(v.Ccq) / 1000.0, labelV},
@@ -302,7 +302,7 @@ func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable)
 func (u *promUnifi) exportRadtable(r report, labels []string, rt unifi.RadioTable, rts unifi.RadioTableStats) {
 	// radio table
 	for _, p := range rt {
-		labelR := append([]string{p.Name, p.Radio}, labels[1:]...)
+		labelR := []string{p.Name, p.Radio, labels[1], labels[2]}
 		r.send([]*metric{
 			{u.UAP.RadioCurrentAntennaGain, prometheus.GaugeValue, p.CurrentAntennaGain, labelR},
 			{u.UAP.RadioHt, prometheus.GaugeValue, p.Ht, labelR},

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -82,8 +82,8 @@ type uap struct {
 }
 
 func descUAP(ns string) *uap {
-	//	labels := []string{"ip", "version", "model", "serial", "type", "mac", "site_name", "name"}
-	labelA := []string{"stat", "site_name", "name"} // stat + labels[6:]
+	//	labels := []string{"type", "site_name", "name"}
+	labelA := []string{"stat", "site_name", "name"} // stat + labels[1:]
 	labelV := []string{"vap_name", "bssid", "radio", "radio_name", "essid", "usage", "site_name", "name"}
 	labelR := []string{"radio_name", "radio", "site_name", "name"}
 	return &uap{
@@ -164,9 +164,11 @@ func descUAP(ns string) *uap {
 }
 
 func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
-	labels := []string{d.IP, d.Version, d.Model, d.Serial, d.Type, d.Mac, d.SiteName, d.Name}
+	labels := []string{d.Type, d.SiteName, d.Name}
+	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
 	// Wireless System Data.
 	r.send([]*metric{
+		{u.Device.Info, prometheus.GaugeValue, 1.0, append(labels, infoLabels...)},
 		{u.Device.Uptime, prometheus.GaugeValue, d.Uptime, labels},
 		{u.Device.TotalTxBytes, prometheus.CounterValue, d.TxBytes, labels},
 		{u.Device.TotalRxBytes, prometheus.CounterValue, d.RxBytes, labels},
@@ -195,8 +197,8 @@ func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 
 func (u *promUnifi) exportUAPstats(r report, labels []string, ap *unifi.Ap) {
 	//	labelA := append([]string{"all"}, labels[2:]...)
-	labelU := append([]string{"user"}, labels[6:]...)
-	labelG := append([]string{"guest"}, labels[6:]...)
+	labelU := append([]string{"user"}, labels[1:]...)
+	labelG := append([]string{"guest"}, labels[1:]...)
 	r.send([]*metric{
 		/* // all
 		{u.UAP.ApWifiTxDropped, prometheus.CounterValue, ap.WifiTxDropped, labelA},
@@ -253,7 +255,7 @@ func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable)
 		if !v.Up.Val {
 			continue
 		}
-		labelV := append([]string{v.Name, v.Bssid, v.Radio, v.RadioName, v.Essid, v.Usage}, labels[6:]...)
+		labelV := append([]string{v.Name, v.Bssid, v.Radio, v.RadioName, v.Essid, v.Usage}, labels[1:]...)
 
 		r.send([]*metric{
 			{u.UAP.VAPCcq, prometheus.GaugeValue, float64(v.Ccq) / 1000.0, labelV},
@@ -300,7 +302,7 @@ func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable)
 func (u *promUnifi) exportRadtable(r report, labels []string, rt unifi.RadioTable, rts unifi.RadioTableStats) {
 	// radio table
 	for _, p := range rt {
-		labelR := append([]string{p.Name, p.Radio}, labels[6:]...)
+		labelR := append([]string{p.Name, p.Radio}, labels[1:]...)
 		r.send([]*metric{
 			{u.UAP.RadioCurrentAntennaGain, prometheus.GaugeValue, p.CurrentAntennaGain, labelR},
 			{u.UAP.RadioHt, prometheus.GaugeValue, p.Ht, labelR},

--- a/pkg/promunifi/udm.go
+++ b/pkg/promunifi/udm.go
@@ -38,7 +38,7 @@ type unifiDevice struct {
 
 func descDevice(ns string) *unifiDevice {
 	labels := []string{"type", "site_name", "name"}
-	infoLabels := []string{"ip", "version", "model", "serial", "mac"}
+	infoLabels := []string{"version", "model", "serial", "mac"}
 	return &unifiDevice{
 		Info:          prometheus.NewDesc(ns+"info", "Device Information", append(labels, infoLabels...), nil),
 		Uptime:        prometheus.NewDesc(ns+"uptime", "Uptime", labels, nil),
@@ -73,7 +73,7 @@ func descDevice(ns string) *unifiDevice {
 // UDM is a collection of stats from USG, USW and UAP. It has no unique stats.
 func (u *promUnifi) exportUDM(r report, d *unifi.UDM) {
 	labels := []string{d.Type, d.SiteName, d.Name}
-	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
+	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac}
 	// Dream Machine System Data.
 	r.send([]*metric{
 		{u.Device.Info, prometheus.GaugeValue, 1.0, append(labels, infoLabels...)},

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -71,9 +71,11 @@ func descUSG(ns string) *usg {
 }
 
 func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
-	labels := []string{d.IP, d.Version, d.Model, d.Serial, d.Type, d.Mac, d.SiteName, d.Name}
+	labels := []string{d.Type, d.SiteName, d.Name}
+	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
 	// Gateway System Data.
 	r.send([]*metric{
+		{u.Device.Info, prometheus.GaugeValue, 1.0, append(labels, infoLabels...)},
 		{u.Device.Uptime, prometheus.GaugeValue, d.Uptime, labels},
 		{u.Device.TotalTxBytes, prometheus.CounterValue, d.TxBytes, labels},
 		{u.Device.TotalRxBytes, prometheus.CounterValue, d.RxBytes, labels},

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -36,7 +36,7 @@ type usg struct {
 }
 
 func descUSG(ns string) *usg {
-	//	labels := []string{"ip", "version", "model", "serial", "type", "mac", "site_name", "name"}
+	//	labels := []string{"version", "model", "serial", "type", "mac", "site_name", "name"}
 	//	labelWan := append([]string{"port"}, labels[6:]...)
 	labels := []string{"port", "site_name", "name"}
 	return &usg{
@@ -72,7 +72,7 @@ func descUSG(ns string) *usg {
 
 func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
 	labels := []string{d.Type, d.SiteName, d.Name}
-	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
+	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac}
 	// Gateway System Data.
 	r.send([]*metric{
 		{u.Device.Info, prometheus.GaugeValue, 1.0, append(labels, infoLabels...)},

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -92,7 +92,7 @@ func descUSW(ns string) *usw {
 
 func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 	labels := []string{d.Type, d.SiteName, d.Name}
-	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
+	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac}
 	if d.HasTemperature.Val {
 		r.send([]*metric{{u.Device.Temperature, prometheus.GaugeValue, d.GeneralTemperature, labels}})
 	}

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -47,8 +47,8 @@ type usw struct {
 
 func descUSW(ns string) *usw {
 	pns := ns + "port_"
-	// labels := []string{"ip", "version", "model", "serial", "type", "mac", "site_name", "name"}
-	labelS := []string{"site_name", "name"} // labels[6:]
+	// labels := []string{"type", "site_name", "name"}
+	labelS := []string{"site_name", "name"} // labels[1:]
 	labelP := []string{"port_id", "port_num", "port_name", "port_mac", "port_ip", "site_name", "name"}
 	return &usw{
 		SwRxPackets:   prometheus.NewDesc(ns+"switch_receive_packets_total", "Switch Packets Received Total", labelS, nil),
@@ -91,7 +91,8 @@ func descUSW(ns string) *usw {
 }
 
 func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
-	labels := []string{d.IP, d.Version, d.Model, d.Serial, d.Type, d.Mac, d.SiteName, d.Name}
+	labels := []string{d.Type, d.SiteName, d.Name}
+	infoLabels := []string{d.IP, d.Version, d.Model, d.Serial, d.Mac}
 	if d.HasTemperature.Val {
 		r.send([]*metric{{u.Device.Temperature, prometheus.GaugeValue, d.GeneralTemperature, labels}})
 	}
@@ -101,6 +102,7 @@ func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 
 	// Switch System Data.
 	r.send([]*metric{
+		{u.Device.Info, prometheus.GaugeValue, 1.0, append(labels, infoLabels...)},
 		{u.Device.Uptime, prometheus.GaugeValue, d.Uptime, labels},
 		{u.Device.TotalMaxPower, prometheus.GaugeValue, d.TotalMaxPower, labels},
 		{u.Device.TotalTxBytes, prometheus.CounterValue, d.TxBytes, labels},
@@ -123,7 +125,7 @@ func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 }
 
 func (u *promUnifi) exportUSWstats(r report, labels []string, sw *unifi.Sw) {
-	labelS := labels[6:]
+	labelS := labels[1:]
 	r.send([]*metric{
 		{u.USW.SwRxPackets, prometheus.CounterValue, sw.RxPackets, labelS},
 		{u.USW.SwRxBytes, prometheus.CounterValue, sw.RxBytes, labelS},


### PR DESCRIPTION
Move some of the excess device inventory labels to an "info" metric.
This reduces query output noise and indexing overhead.

These labels can still be used for filtering with a `group_left` query.

Signed-off-by: Ben Kochie <superq@gmail.com>