### PR TITLE
Prevent poller from dying from an error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,7 +103,7 @@
   name = "golang.org/x/sys"
   packages = ["windows"]
   pruneopts = "UT"
-  revision = "ce4227a45e2eb77e5c847278dcc6a626742e2945"
+  revision = "eeba5f6aabab6d6594a9191d6bfeaca5fa6a8248"
 
 [[projects]]
   digest = "1:87738e338f505d3e3be1f80d36b53f3c4e73be9b7ad4ccae46abbe9ef04f3f71"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:50708c8fc92aec981df5c446581cf9f90ba9e2a5692118e0ce75d4534aaa14a2"
+  digest = "1:00e5ad58045d6d2a6c9e65d1809ff2594bc396e911712ae892a93976fdece115"
   name = "github.com/influxdata/influxdb1-client"
   packages = [
     "models",
@@ -35,7 +35,7 @@
     "v2",
   ]
   pruneopts = "UT"
-  revision = "fc22c7df067eefd070157f157893fbce961d6359"
+  revision = "8bf82d3c094dc06be9da8e5bf9d3589b6ea032ae"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
@@ -103,15 +103,15 @@
   name = "golang.org/x/sys"
   packages = ["windows"]
   pruneopts = "UT"
-  revision = "eeba5f6aabab6d6594a9191d6bfeaca5fa6a8248"
+  revision = "ac6580df4449443a05718fd7858c1f91ad5f8d20"
 
 [[projects]]
-  digest = "1:87738e338f505d3e3be1f80d36b53f3c4e73be9b7ad4ccae46abbe9ef04f3f71"
+  digest = "1:2883cea734f2766f41ff9c9d4aefccccc53e3d44f5c8b08893b9c218cf666722"
   name = "golift.io/unifi"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ba857a3a04311fed362cb43fa7bf4066bc3a7e55"
-  version = "v4.1.5"
+  revision = "a607fe940c6a563c6994f2c945394b19d2183b1c"
+  version = "v4.1.6"
 
 [[projects]]
   digest = "1:b75b3deb2bce8bc079e16bb2aecfe01eb80098f5650f9e93e5643ca8b7b73737"

--- a/pkg/influxunifi/uap.go
+++ b/pkg/influxunifi/uap.go
@@ -7,8 +7,8 @@ import (
 // batchUAP generates Wireless-Access-Point datapoints for InfluxDB.
 // These points can be passed directly to influx.
 func (u *InfluxUnifi) batchUAP(r report, s *unifi.UAP) {
-	if s.Stat.Ap == nil {
-		s.Stat.Ap = &unifi.Ap{}
+	if !s.Adopted.Val || s.Locating.Val {
+		return
 	}
 	tags := map[string]string{
 		"mac":       s.Mac,
@@ -36,6 +36,9 @@ func (u *InfluxUnifi) batchUAP(r report, s *unifi.UAP) {
 }
 
 func (u *InfluxUnifi) processUAPstats(ap *unifi.Ap) map[string]interface{} {
+	if ap == nil {
+		return map[string]interface{}{}
+	}
 	// Accumulative Statistics.
 	return map[string]interface{}{
 		"stat_user-rx_packets":  ap.UserRxPackets.Val,

--- a/pkg/influxunifi/usg.go
+++ b/pkg/influxunifi/usg.go
@@ -7,8 +7,8 @@ import (
 // batchUSG generates Unifi Gateway datapoints for InfluxDB.
 // These points can be passed directly to influx.
 func (u *InfluxUnifi) batchUSG(r report, s *unifi.USG) {
-	if s.Stat.Gw == nil {
-		s.Stat.Gw = &unifi.Gw{}
+	if !s.Adopted.Val || s.Locating.Val {
+		return
 	}
 	tags := map[string]string{
 		"mac":       s.Mac,
@@ -74,6 +74,9 @@ func (u *InfluxUnifi) batchUSG(r report, s *unifi.USG) {
 	*/
 }
 func (u *InfluxUnifi) batchUSGstat(ss unifi.SpeedtestStatus, gw *unifi.Gw, ul unifi.Uplink) map[string]interface{} {
+	if gw == nil {
+		return map[string]interface{}{}
+	}
 	return map[string]interface{}{
 		"uplink_latency":                 ul.Latency.Val,
 		"uplink_speed":                   ul.Speed.Val,

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -49,11 +50,12 @@ const ENVConfigPrefix = "UP_"
 
 // UnifiPoller contains the application startup data, and auth info for UniFi & Influx.
 type UnifiPoller struct {
-	Influx    *influxunifi.InfluxUnifi
-	Unifi     *unifi.Unifi
-	Flag      *Flag
-	Config    *Config
-	LastCheck time.Time
+	Influx     *influxunifi.InfluxUnifi
+	Unifi      *unifi.Unifi
+	Flag       *Flag
+	Config     *Config
+	LastCheck  time.Time
+	sync.Mutex // locks the Unifi struct member when re-authing to unifi.
 }
 
 // Flag represents the CLI args available and their settings.

--- a/pkg/poller/dumper.go
+++ b/pkg/poller/dumper.go
@@ -35,9 +35,9 @@ func (u *UnifiPoller) DumpJSONPayload() (err error) {
 	case err != nil:
 		return err
 	case StringInSlice(u.Flag.DumpJSON, []string{"d", "device", "devices"}):
-		return u.dumpSitesJSON(unifi.DevicePath, "Devices", sites)
+		return u.dumpSitesJSON(unifi.APIDevicePath, "Devices", sites)
 	case StringInSlice(u.Flag.DumpJSON, []string{"client", "clients", "c"}):
-		return u.dumpSitesJSON(unifi.ClientPath, "Clients", sites)
+		return u.dumpSitesJSON(unifi.APIClientPath, "Clients", sites)
 	case strings.HasPrefix(u.Flag.DumpJSON, "other "):
 		apiPath := strings.SplitN(u.Flag.DumpJSON, " ", 2)[1]
 		_, _ = fmt.Fprintf(os.Stderr, "[INFO] Dumping Path '%s':\n", apiPath)

--- a/pkg/poller/helpers.go
+++ b/pkg/poller/helpers.go
@@ -8,15 +8,6 @@ import (
 
 const callDepth = 2
 
-// LogError logs an error and increments the error counter.
-// Should be used in the poller loop.
-func (u *UnifiPoller) LogError(err error, prefix string) {
-	if err != nil {
-		u.errorCount++
-		_ = log.Output(callDepth, fmt.Sprintf("[ERROR] %v: %v", prefix, err))
-	}
-}
-
 // StringInSlice returns true if a string is in a slice.
 func StringInSlice(str string, slice []string) bool {
 	for _, s := range slice {
@@ -41,7 +32,7 @@ func (u *UnifiPoller) LogDebugf(m string, v ...interface{}) {
 	}
 }
 
-// LogErrorf prints an error log entry. This is used for external library logging.
+// LogErrorf prints an error log entry.
 func (u *UnifiPoller) LogErrorf(m string, v ...interface{}) {
 	_ = log.Output(callDepth, fmt.Sprintf("[ERROR] "+m, v...))
 }

--- a/pkg/poller/influx.go
+++ b/pkg/poller/influx.go
@@ -12,6 +12,7 @@ func (u *UnifiPoller) GetInfluxDB() (err error) {
 	if u.Influx != nil {
 		return nil
 	}
+
 	u.Influx, err = influxunifi.New(&influxunifi.Config{
 		Database: u.Config.InfluxDB,
 		User:     u.Config.InfluxUser,
@@ -22,7 +23,9 @@ func (u *UnifiPoller) GetInfluxDB() (err error) {
 	if err != nil {
 		return fmt.Errorf("influxdb: %v", err)
 	}
+
 	u.Logf("Logging Measurements to InfluxDB at %s as user %s", u.Config.InfluxURL, u.Config.InfluxUser)
+
 	return nil
 }
 
@@ -40,6 +43,7 @@ func (u *UnifiPoller) CollectAndProcess() error {
 	if err != nil {
 		return err
 	}
+
 	u.AugmentMetrics(metrics)
 
 	report, err := u.Influx.ReportMetrics(metrics)
@@ -54,9 +58,11 @@ func (u *UnifiPoller) CollectAndProcess() error {
 // LogInfluxReport writes a log message after exporting to influxdb.
 func (u *UnifiPoller) LogInfluxReport(r *influxunifi.Report) {
 	idsMsg := ""
+
 	if u.Config.SaveIDS {
 		idsMsg = fmt.Sprintf("IDS Events: %d, ", len(r.Metrics.IDSList))
 	}
+
 	u.Logf("UniFi Metrics Recorded. Sites: %d, Clients: %d, "+
 		"UAP: %d, USG/UDM: %d, USW: %d, %sPoints: %d, Fields: %d, Errs: %d, Elapsed: %v",
 		len(r.Metrics.Sites), len(r.Metrics.Clients), len(r.Metrics.UAPs),

--- a/pkg/poller/influx.go
+++ b/pkg/poller/influx.go
@@ -42,7 +42,7 @@ func (u *UnifiPoller) CollectAndProcess() error {
 	u.AugmentMetrics(metrics)
 	report, err := u.Influx.ReportMetrics(metrics)
 	if err != nil {
-		u.LogError(err, "processing metrics")
+		u.LogErrorf("processing metrics: %v", err)
 		return err
 	}
 	u.LogInfluxReport(report)

--- a/pkg/poller/influx.go
+++ b/pkg/poller/influx.go
@@ -44,7 +44,6 @@ func (u *UnifiPoller) CollectAndProcess() error {
 
 	report, err := u.Influx.ReportMetrics(metrics)
 	if err != nil {
-		u.LogErrorf("processing metrics: %v", err)
 		return err
 	}
 

--- a/pkg/poller/influx.go
+++ b/pkg/poller/influx.go
@@ -35,16 +35,19 @@ func (u *UnifiPoller) CollectAndProcess() error {
 	if err := u.GetInfluxDB(); err != nil {
 		return err
 	}
+
 	metrics, err := u.CollectMetrics()
 	if err != nil {
 		return err
 	}
 	u.AugmentMetrics(metrics)
+
 	report, err := u.Influx.ReportMetrics(metrics)
 	if err != nil {
 		u.LogErrorf("processing metrics: %v", err)
 		return err
 	}
+
 	u.LogInfluxReport(report)
 	return nil
 }

--- a/pkg/poller/prometheus.go
+++ b/pkg/poller/prometheus.go
@@ -35,7 +35,7 @@ func (u *UnifiPoller) ExportMetrics() (*metrics.Metrics, error) {
 		u.LogErrorf("collecting metrics: %v", err)
 		u.Logf("Re-authenticating to UniFi Controller")
 
-		if err := u.Unifi.Login(); err != nil {
+		if err := u.GetUnifi(); err != nil {
 			u.LogErrorf("re-authenticating: %v", err)
 			return nil, err
 		}

--- a/pkg/poller/prometheus.go
+++ b/pkg/poller/prometheus.go
@@ -23,6 +23,7 @@ func (u *UnifiPoller) RunPrometheus() error {
 		LoggingFn:    u.LogExportReport,
 		ReportErrors: true, // XXX: Does this need to be configurable?
 	}))
+
 	return http.ListenAndServe(u.Config.HTTPListen, nil)
 }
 

--- a/pkg/poller/prometheus.go
+++ b/pkg/poller/prometheus.go
@@ -15,7 +15,7 @@ const oneDecimalPoint = 10
 
 // RunPrometheus starts the web server and registers the collector.
 func (u *UnifiPoller) RunPrometheus() error {
-	u.Logf("Exporting Measurements at https://%s/metrics for Prometheus", u.Config.HTTPListen)
+	u.Logf("Exporting Measurements for Prometheus at https://%s/metrics", u.Config.HTTPListen)
 	http.Handle("/metrics", promhttp.Handler())
 	prometheus.MustRegister(promunifi.NewUnifiCollector(promunifi.UnifiCollectorCnfg{
 		Namespace:    strings.Replace(u.Config.Namespace, "-", "", -1),
@@ -34,8 +34,9 @@ func (u *UnifiPoller) ExportMetrics() (*metrics.Metrics, error) {
 	if err != nil {
 		u.LogErrorf("collecting metrics: %v", err)
 		u.Logf("Re-authenticating to UniFi Controller")
+
 		if err := u.Unifi.Login(); err != nil {
-			u.LogError(err, "re-authenticating")
+			u.LogErrorf("re-authenticating: %v", err)
 			return nil, err
 		}
 

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -124,14 +124,16 @@ func (u *UnifiPoller) Run() error {
 func (u *UnifiPoller) PollController() {
 	interval := u.Config.Interval.Round(time.Second)
 	log.Printf("[INFO] Everything checks out! Poller started, InfluxDB interval: %v", interval)
+
 	ticker := time.NewTicker(interval)
 	for u.LastCheck = range ticker.C {
 		if err := u.CollectAndProcess(); err != nil {
 			u.LogErrorf("%v", err)
+
 			if u.Unifi != nil {
 				u.Unifi.CloseIdleConnections()
+				u.Unifi = nil // trigger re-auth in unifi.go.
 			}
-			u.Unifi = nil // trigger re-auth in unifi.go.
 		}
 	}
 }

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -28,7 +28,10 @@ func New() *UnifiPoller {
 			SaveSites:  true,
 			HTTPListen: defaultHTTPListen,
 			Namespace:  appName,
-		}, Flag: &Flag{ConfigFile: DefaultConfFile},
+		},
+		Flag: &Flag{
+			ConfigFile: DefaultConfFile,
+		},
 	}
 }
 
@@ -125,6 +128,7 @@ func (u *UnifiPoller) PollController() {
 	for u.LastCheck = range ticker.C {
 		if err := u.CollectAndProcess(); err != nil {
 			u.LogErrorf("%v", err)
+			u.Unifi.CloseIdleConnections()
 			u.Unifi = nil // trigger re-auth in unifi.go.
 		}
 	}

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -128,7 +128,9 @@ func (u *UnifiPoller) PollController() {
 	for u.LastCheck = range ticker.C {
 		if err := u.CollectAndProcess(); err != nil {
 			u.LogErrorf("%v", err)
-			u.Unifi.CloseIdleConnections()
+			if u.Unifi != nil {
+				u.Unifi.CloseIdleConnections()
+			}
 			u.Unifi = nil // trigger re-auth in unifi.go.
 		}
 	}

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -36,6 +36,7 @@ func New() *UnifiPoller {
 // Parses cli flags, parses config file, parses env vars, sets up logging, then:
 // - dumps a json payload OR - executes Run().
 func (u *UnifiPoller) Start() error {
+	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags)
 	u.Flag.Parse(os.Args[1:])
 

--- a/pkg/poller/unifi.go
+++ b/pkg/poller/unifi.go
@@ -76,20 +76,20 @@ func (u *UnifiPoller) CollectMetrics() (*metrics.Metrics, error) {
 	var err error
 	// Get the sites we care about.
 	if m.Sites, err = u.GetFilteredSites(); err != nil {
-		u.LogErrorf("unifi.GetSites(): %v", err)
+		return m, fmt.Errorf("unifi.GetSites(): %v", err)
 	}
 	if u.Config.SaveIDS {
 		m.IDSList, err = u.Unifi.GetIDS(m.Sites, time.Now().Add(u.Config.Interval.Duration), time.Now())
-		u.LogErrorf("unifi.GetIDS(): %v", err)
+		return m, fmt.Errorf("unifi.GetIDS(): %v", err)
 	}
 	// Get all the points.
 	if m.Clients, err = u.Unifi.GetClients(m.Sites); err != nil {
-		u.LogErrorf("unifi.GetClients(): %v", err)
+		return m, fmt.Errorf("unifi.GetClients(): %v", err)
 	}
 	if m.Devices, err = u.Unifi.GetDevices(m.Sites); err != nil {
-		u.LogErrorf("unifi.GetDevices(): %v", err)
+		return m, fmt.Errorf("unifi.GetDevices(): %v", err)
 	}
-	return m, err
+	return m, nil
 }
 
 // AugmentMetrics is our middleware layer between collecting metrics and writing them.

--- a/pkg/poller/unifi.go
+++ b/pkg/poller/unifi.go
@@ -69,31 +69,37 @@ FIRST:
 
 // CollectMetrics grabs all the measurements from a UniFi controller and returns them.
 func (u *UnifiPoller) CollectMetrics() (*metrics.Metrics, error) {
+	var err error
+
 	if u.Unifi == nil || u.Config.ReAuth {
 		// Some users need to re-auth every interval because the cookie times out.
 		// Sometimes we hit this path when the controller dies.
-		u.LogDebugf("Re-authenticating to UniFi Controller")
+		u.Logf("Re-authenticating to UniFi Controller")
 		if err := u.GetUnifi(); err != nil {
 			return nil, err
 		}
 	}
+
 	m := &metrics.Metrics{TS: u.LastCheck} // At this point, it's the Current Check.
-	var err error
 	// Get the sites we care about.
 	if m.Sites, err = u.GetFilteredSites(); err != nil {
 		return m, fmt.Errorf("unifi.GetSites(): %v", err)
 	}
+
 	if u.Config.SaveIDS {
 		m.IDSList, err = u.Unifi.GetIDS(m.Sites, time.Now().Add(u.Config.Interval.Duration), time.Now())
 		return m, fmt.Errorf("unifi.GetIDS(): %v", err)
 	}
+
 	// Get all the points.
 	if m.Clients, err = u.Unifi.GetClients(m.Sites); err != nil {
 		return m, fmt.Errorf("unifi.GetClients(): %v", err)
 	}
+
 	if m.Devices, err = u.Unifi.GetDevices(m.Sites); err != nil {
 		return m, fmt.Errorf("unifi.GetDevices(): %v", err)
 	}
+
 	return m, nil
 }
 

--- a/pkg/poller/unifi.go
+++ b/pkg/poller/unifi.go
@@ -11,6 +11,11 @@ import (
 
 // GetUnifi returns a UniFi controller interface.
 func (u *UnifiPoller) GetUnifi() (err error) {
+	u.Lock()
+	defer u.Unlock()
+	if u.Unifi != nil {
+		u.Unifi.CloseIdleConnections()
+	}
 	// Create an authenticated session to the Unifi Controller.
 	u.Unifi, err = unifi.NewUnifi(&unifi.Config{
 		User:      u.Config.UnifiUser,

--- a/pkg/poller/unifi.go
+++ b/pkg/poller/unifi.go
@@ -67,16 +67,16 @@ func (u *UnifiPoller) CollectMetrics() (*metrics.Metrics, error) {
 	var err error
 	// Get the sites we care about.
 	m.Sites, err = u.GetFilteredSites()
-	u.LogError(err, "unifi.GetSites()")
+	u.LogErrorf("unifi.GetSites(): %v", err)
 	if u.Config.SaveIDS {
 		m.IDSList, err = u.Unifi.GetIDS(m.Sites, time.Now().Add(u.Config.Interval.Duration), time.Now())
-		u.LogError(err, "unifi.GetIDS()")
+		u.LogErrorf("unifi.GetIDS(): %v", err)
 	}
 	// Get all the points.
 	m.Clients, err = u.Unifi.GetClients(m.Sites)
-	u.LogError(err, "unifi.GetClients()")
+	u.LogErrorf("unifi.GetClients(): %v", err)
 	m.Devices, err = u.Unifi.GetDevices(m.Sites)
-	u.LogError(err, "unifi.GetDevices()")
+	u.LogErrorf("unifi.GetDevices(): %v", err)
 	return m, err
 }
 

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -3,7 +3,6 @@ package promunifi
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"strings"
 	"sync"
@@ -113,7 +112,6 @@ func (u *promUnifi) Collect(ch chan<- prometheus.Metric) {
 	defer r.close()
 
 	if r.Metrics, err = r.cf.CollectFn(); err != nil {
-		log.Println("Error", err)
 		r.error(ch, prometheus.NewInvalidDesc(fmt.Errorf("metric fetch failed")), err)
 		return
 	}

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -3,6 +3,7 @@ package promunifi
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 	"strings"
 	"sync"
@@ -112,6 +113,7 @@ func (u *promUnifi) Collect(ch chan<- prometheus.Metric) {
 	defer r.close()
 
 	if r.Metrics, err = r.cf.CollectFn(); err != nil {
+		log.Println("Error", err)
 		r.error(ch, prometheus.NewInvalidDesc(fmt.Errorf("metric fetch failed")), err)
 		return
 	}

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -1,8 +1,6 @@
 package promunifi
 
 import (
-	"log"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"golift.io/unifi"
 )
@@ -178,10 +176,8 @@ func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 // udm doesn't have these stats exposed yet, so pass 2 or 6 metrics.
 func (u *promUnifi) exportUAPstats(r report, labels []string, ap *unifi.Ap, bytes ...unifi.FlexInt) {
 	if ap == nil {
-		log.Println("ap was nil?!", labels[2])
 		return
 	}
-	log.Println("ap not nil")
 	labelU := []string{"user", labels[1], labels[2]}
 	labelG := []string{"guest", labels[1], labels[2]}
 	r.send([]*metric{

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -159,6 +159,9 @@ func descUAP(ns string) *uap {
 }
 
 func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
+	if !d.Adopted.Val || d.Locating.Val {
+		return
+	}
 	labels := []string{d.Type, d.SiteName, d.Name}
 	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac, d.IP, d.ID, d.Bytes.Txt, d.Uptime.Txt}
 	u.exportUAPstats(r, labels, d.Stat.Ap, d.BytesD, d.TxBytesD, d.RxBytesD, d.BytesR)

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -181,6 +181,7 @@ func (u *promUnifi) exportUAPstats(r report, labels []string, ap *unifi.Ap, byte
 		log.Println("ap was nil?!", labels[2])
 		return
 	}
+	log.Println("ap not nil")
 	labelU := []string{"user", labels[1], labels[2]}
 	labelG := []string{"guest", labels[1], labels[2]}
 	r.send([]*metric{

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -1,6 +1,8 @@
 package promunifi
 
 import (
+	"log"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"golift.io/unifi"
 )
@@ -175,6 +177,10 @@ func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 
 // udm doesn't have these stats exposed yet, so pass 2 or 6 metrics.
 func (u *promUnifi) exportUAPstats(r report, labels []string, ap *unifi.Ap, bytes ...unifi.FlexInt) {
+	if ap == nil {
+		log.Println("ap was nil?!", labels[2])
+		return
+	}
 	labelU := []string{"user", labels[1], labels[2]}
 	labelG := []string{"guest", labels[1], labels[2]}
 	r.send([]*metric{

--- a/pkg/promunifi/udm.go
+++ b/pkg/promunifi/udm.go
@@ -60,6 +60,9 @@ func descDevice(ns string) *unifiDevice {
 
 // UDM is a collection of stats from USG, USW and UAP. It has no unique stats.
 func (u *promUnifi) exportUDM(r report, d *unifi.UDM) {
+	if !d.Adopted.Val || d.Locating.Val {
+		return
+	}
 	labels := []string{d.Type, d.SiteName, d.Name}
 	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac, d.IP, d.ID, d.Bytes.Txt, d.Uptime.Txt}
 	// Shared data (all devices do this).

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -69,6 +69,9 @@ func descUSG(ns string) *usg {
 }
 
 func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
+	if !d.Adopted.Val || d.Locating.Val {
+		return
+	}
 	labels := []string{d.Type, d.SiteName, d.Name}
 	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac, d.IP, d.ID, d.Bytes.Txt, d.Uptime.Txt}
 	// Gateway System Data.

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -85,6 +85,9 @@ func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
 
 // Gateway States
 func (u *promUnifi) exportUSGstats(r report, labels []string, gw *unifi.Gw, st unifi.SpeedtestStatus, ul unifi.Uplink) {
+	if gw == nil {
+		return
+	}
 	labelLan := []string{"lan", labels[1], labels[2]}
 	labelWan := []string{"all", labels[1], labels[2]}
 	r.send([]*metric{

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -116,6 +116,9 @@ func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 
 // Switch Stats
 func (u *promUnifi) exportUSWstats(r report, labels []string, sw *unifi.Sw) {
+	if sw == nil {
+		return
+	}
 	labelS := labels[1:]
 	r.send([]*metric{
 		{u.USW.SwRxPackets, counter, sw.RxPackets, labelS},

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -91,6 +91,9 @@ func descUSW(ns string) *usw {
 }
 
 func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
+	if !d.Adopted.Val || d.Locating.Val {
+		return
+	}
 	labels := []string{d.Type, d.SiteName, d.Name}
 	infoLabels := []string{d.Version, d.Model, d.Serial, d.Mac, d.IP, d.ID, d.Bytes.Txt, d.Uptime.Txt}
 	u.exportUSWstats(r, labels, d.Stat.Sw)


### PR DESCRIPTION
As the title says. Remove all the `return err` statements that make it die when it gets errors from the controller or influxdb. Now, it should just keep running, and retrying at every interval.

This is for _you_, unRAID users.