### PR TITLE
Add a build info metric to Prometheus

### DIFF
--- a/.metadata.sh
+++ b/.metadata.sh
@@ -43,6 +43,7 @@ VERSION="$(echo $VVERSION | tr -d v | grep -E '^\S+$' || echo development)"
 # This produces a 0 in some envirnoments (like Homebrew), but it's only used for packages.
 ITERATION=$(git rev-list --count --all || echo 0)
 DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+BRANCH="$(git rev-parse --abbrev-ref HEAD || echo unknown)"
 COMMIT="$(git rev-parse --short HEAD || echo 0)"
 
 # Used by homebrew downloads.
@@ -50,4 +51,4 @@ COMMIT="$(git rev-parse --short HEAD || echo 0)"
 # This is a custom download path for homebrew formula.
 SOURCE_PATH=https://golift.io/${BINARY}/archive/v${VERSION}.tar.gz
 
-export IMPORT_PATH SOURCE_URL URL VERSION_PATH VVERSION VERSION ITERATION DATE COMMIT SOURCE_PATH
+export IMPORT_PATH SOURCE_URL URL VERSION_PATH VVERSION VERSION ITERATION DATE BRANCH COMMIT SOURCE_PATH

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,12 +66,13 @@
   revision = "d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e"
 
 [[projects]]
-  digest = "1:f119e3205d3a1f0f19dbd7038eb37528e2c6f0933269dc344e305951fb87d632"
+  digest = "1:7dec9ab2db741c280b89b142b08ea142824152c5f40fb1f90c35b6ef7a694456"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
     "model",
+    "version",
   ]
   pruneopts = "UT"
   revision = "287d3e634a1e550c9e463dd7e5a75a422c614505"
@@ -129,6 +130,7 @@
     "github.com/influxdata/influxdb1-client/v2",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/common/version",
     "github.com/spf13/pflag",
     "golift.io/unifi",
     "gopkg.in/yaml.v2",

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ $(PACKAGE_SCRIPTS) \
 --config-files "/etc/$(BINARY)/$(CONFIG_FILE)"
 endef
 
+VERSION_LDFLAGS:= \
+  -X $(IMPORT_PATH)/vendor/github.com/prometheus/common/version.Branch=$(BRANCH) \
+  -X $(IMPORT_PATH)/vendor/github.com/prometheus/common/version.BuildDate=$(DATE) \
+  -X $(IMPORT_PATH)/vendor/github.com/prometheus/common/version.Revision=$(COMMIT) \
+  -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)
+
 # Makefile targets follow.
 
 all: build
@@ -89,40 +95,40 @@ README.html: md2roff
 
 build: $(BINARY)
 $(BINARY): main.go pkg/*/*.go
-	go build -o $(BINARY) -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	go build -o $(BINARY) -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 linux: $(BINARY).amd64.linux
 $(BINARY).amd64.linux: main.go pkg/*/*.go
 	# Building linux 64-bit x86 binary.
-	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 linux386: $(BINARY).i386.linux
 $(BINARY).i386.linux: main.go pkg/*/*.go
 	# Building linux 32-bit x86 binary.
-	GOOS=linux GOARCH=386 go build -o $@ -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	GOOS=linux GOARCH=386 go build -o $@ -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 arm: arm64 armhf
 
 arm64: $(BINARY).arm64.linux
 $(BINARY).arm64.linux: main.go pkg/*/*.go
 	# Building linux 64-bit ARM binary.
-	GOOS=linux GOARCH=arm64 go build -o $@ -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	GOOS=linux GOARCH=arm64 go build -o $@ -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 armhf: $(BINARY).armhf.linux
 $(BINARY).armhf.linux: main.go pkg/*/*.go
 	# Building linux 32-bit ARM binary.
-	GOOS=linux GOARCH=arm GOARM=6 go build -o $@ -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	GOOS=linux GOARCH=arm GOARM=6 go build -o $@ -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 macos: $(BINARY).amd64.macos
 $(BINARY).amd64.macos: main.go pkg/*/*.go
 	# Building darwin 64-bit x86 binary.
-	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 exe: $(BINARY).amd64.exe
 windows: $(BINARY).amd64.exe
 $(BINARY).amd64.exe: main.go pkg/*/*.go
 	# Building windows 64-bit x86 binary.
-	GOOS=windows GOARCH=amd64 go build -o $@ -ldflags "-w -s -X $(VERSION_PATH)=$(VERSION)-$(ITERATION)"
+	GOOS=windows GOARCH=amd64 go build -o $@ -ldflags "-w -s $(VERSION_LDFLAGS)"
 
 # Packages
 

--- a/pkg/poller/prometheus.go
+++ b/pkg/poller/prometheus.go
@@ -9,6 +9,7 @@ import (
 	"github.com/davidnewhall/unifi-poller/pkg/promunifi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/version"
 )
 
 const oneDecimalPoint = 10
@@ -23,6 +24,9 @@ func (u *UnifiPoller) RunPrometheus() error {
 		LoggingFn:    u.LogExportReport,
 		ReportErrors: true, // XXX: Does this need to be configurable?
 	}))
+
+	version.Version = Version
+	prometheus.MustRegister(version.NewCollector("unifipoller"))
 
 	return http.ListenAndServe(u.Config.HTTPListen, nil)
 }

--- a/pkg/poller/prometheus.go
+++ b/pkg/poller/prometheus.go
@@ -18,15 +18,16 @@ const oneDecimalPoint = 10
 func (u *UnifiPoller) RunPrometheus() error {
 	u.Logf("Exporting Measurements for Prometheus at https://%s/metrics", u.Config.HTTPListen)
 	http.Handle("/metrics", promhttp.Handler())
+	ns := strings.Replace(u.Config.Namespace, "-", "", -1)
 	prometheus.MustRegister(promunifi.NewUnifiCollector(promunifi.UnifiCollectorCnfg{
-		Namespace:    strings.Replace(u.Config.Namespace, "-", "", -1),
+		Namespace:    ns,
 		CollectFn:    u.ExportMetrics,
 		LoggingFn:    u.LogExportReport,
 		ReportErrors: true, // XXX: Does this need to be configurable?
 	}))
 
 	version.Version = Version
-	prometheus.MustRegister(version.NewCollector("unifipoller"))
+	prometheus.MustRegister(version.NewCollector(ns))
 
 	return http.ListenAndServe(u.Config.HTTPListen, nil)
 }


### PR DESCRIPTION
Include `unifi_poller_build_info` as a Prometheus metric.

Signed-off-by: Ben Kochie <superq@gmail.com>